### PR TITLE
Add encoding='utf-8' to deleted_comments.txt writes and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# User credentials — must never be committed
+Credentials.txt
+
+# Runtime-generated deletion logs
+deleted_comments.txt
+deleted_posts.txt
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo

--- a/commentCleaner.py
+++ b/commentCleaner.py
@@ -103,7 +103,7 @@ def delete_old_comments(reddit, username, days_old, comments_deleted):
     for comment in reddit.redditor(username).comments.new(limit=None):
         if time.time() - comment.created_utc > days_old * 24 * 60 * 60:
             comment_date = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%d %H:%M:%S")
-            with open('deleted_comments.txt', 'a') as f:
+            with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
                 # Write the date, karma score, and comment body to the file
                 f.write(f"{comment_date} | {comment.score} | {comment.body}\n")
             try:
@@ -129,7 +129,7 @@ def remove_comments_with_negative_karma(reddit, username, comments_deleted):
     for comment in reddit.redditor(username).comments.new(limit=None):
         if comment.score <= 0:
             comment_date = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%d %H:%M:%S")
-            with open('deleted_comments.txt', 'a') as f:
+            with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
                 # Write the date, karma score, and comment body to the file
                 f.write(f"{comment_date} | {comment.score} | {comment.body}\n")
             try:
@@ -162,7 +162,7 @@ def remove_comments_with_one_karma_and_no_replies(reddit, username, comments_del
             # Format the date of the comment
             comment_date = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%d %H:%M:%S")
 
-            with open('deleted_comments.txt', 'a') as f:
+            with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
                 # Write the date, karma score, and comment to the file
                 f.write(f"{comment_date} | {comment.score} | {comment.body}\n")
             try:


### PR DESCRIPTION
commentCleaner.py opened deleted_comments.txt using the default system encoding, while PostCleaner.py already used encoding='utf-8'. On Windows systems (or any locale without UTF-8 as default) comment bodies containing non-ASCII characters (emoji, accented letters, CJK) would either be corrupted or raise a UnicodeEncodeError at runtime.

Also adds .gitignore to prevent accidental commits of:
- Credentials.txt (Reddit API secrets)
- deleted_comments.txt / deleted_posts.txt (user data, runtime output)
- Python bytecode caches (__pycache__, *.pyc)

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d