### PR TITLE
Fix comment.replies always empty in remove_comments_with_one_karma_an…

### DIFF
--- a/commentCleaner.py
+++ b/commentCleaner.py
@@ -157,6 +157,8 @@ def remove_comments_with_one_karma_and_no_replies(reddit, username, comments_del
     one_week_ago = datetime.utcnow() - timedelta(days=7)
 
     for comment in reddit.redditor(username).comments.new(limit=None):
+        # comment.replies is not populated by default; refresh() fetches the full thread
+        comment.refresh()
         # Check if the comment meets the criteria
         if comment.score <= 1 and len(comment.replies) == 0 and datetime.utcfromtimestamp(comment.created_utc) < one_week_ago:
             # Format the date of the comment


### PR DESCRIPTION
…d_no_replies

PRAW does not populate comment.replies for Comment objects returned by redditor().comments.new(). Without calling comment.refresh() first, comment.replies is always an empty CommentForest regardless of how many replies actually exist. This caused mode 3 to over-delete: any comment with score <= 1 and age > 7 days would be removed, even those with active reply threads.

Fix: call comment.refresh() before the replies check to fetch the full comment tree from the API.

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d