### PR TITLE
Fix PostCleaner.py double-deletion and invalid method call

### DIFF
--- a/PostCleaner.py
+++ b/PostCleaner.py
@@ -101,20 +101,17 @@ def delete_old_posts(reddit, username, days_old, posts_deleted):
     """
     for submission in reddit.redditor(username).submissions.new(limit=None):
         if submission.created_utc < (time.time() - (days_old * 86400)):
-            submission.delete()
-            posts_deleted += 1
-            print(f"Deleted post: {submission.title}")
             # save post title, date, karma, and subreddit deleted to a file with utf-8 encoding
             with open("deleted_posts.txt", "a", encoding="utf-8") as f:
                 f.write(f"{submission.title}, {datetime.utcfromtimestamp(submission.created_utc)}, {submission.score}, {submission.subreddit.display_name}\n")
             try:
                 submission.edit(".")
                 submission.delete()
-                submission.append(submission)
-                
+                posts_deleted += 1
+                print(f"Deleted post: {submission.title}")
             except praw.exceptions.APIException as e:
-                print(f"Error removing comment: {e}")
-                
+                print(f"Error removing post: {e}")
+
     print(f"Deleted {posts_deleted} posts.")
 
         


### PR DESCRIPTION
The delete_old_posts function had three bugs:
1. submission.delete() was called before submission.edit("."), meaning the content was deleted without being overwritten first (bypassing the anti-archiving step that commentCleaner.py correctly performs).
2. A second try block then attempted submission.edit(".") and submission.delete() again on an already-deleted object, which would raise a PRAW API error on every post.
3. submission.append(submission) is not a valid Submission method and would always raise AttributeError, swallowed by the except clause.

Fix: log to file first (while attributes are still readable), then edit-then-delete once inside a single try/except block.

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d