### PR TITLE
Add Google Drive log upload to web app and CLI scripts

### DIFF
--- a/PostCleaner.py
+++ b/PostCleaner.py
@@ -2,6 +2,8 @@ import praw
 import time
 from datetime import datetime
 
+from drive_upload import maybe_upload_logs
+
 
 def get_reddit_credentials(credentials_file="Credentials.txt"):
     """
@@ -124,6 +126,7 @@ def main():
     days_old = get_days_old()
     posts_deleted = 0
     delete_old_posts(reddit, username, days_old, posts_deleted)
+    maybe_upload_logs("deleted_posts.txt")
 
 
 if __name__ == "__main__":

--- a/commentCleaner.py
+++ b/commentCleaner.py
@@ -2,6 +2,8 @@ import praw
 import time
 from datetime import datetime, timedelta
 
+from drive_upload import maybe_upload_logs
+
 def get_reddit_credentials(credentials_file="Credentials.txt"):
     """
     Prompt the user to input Reddit client credentials.
@@ -205,6 +207,7 @@ def main():
 
         if len(comments_deleted) > 0:
             print("The script ran successfully and deleted {} comments.".format(len(comments_deleted)))
+            maybe_upload_logs("deleted_comments.txt")
             comments_deleted = []
         else:
             print("There were no comments to delete.")

--- a/drive_upload.py
+++ b/drive_upload.py
@@ -1,0 +1,127 @@
+"""
+Google Drive upload helper for RedditCommentCleaner.
+
+Uploads deletion log files (deleted_comments.txt, deleted_posts.txt) to a
+Google Drive folder using a service account.  If an existing file with the
+same name is already present in the folder it is updated in-place rather
+than creating a duplicate.
+
+The module is opt-in: if the required environment variables are not set,
+`maybe_upload_logs()` silently returns an empty list so all existing
+functionality continues to work without any Drive configuration.
+
+Setup
+-----
+1. Go to https://console.cloud.google.com and create (or select) a project.
+2. Enable the **Google Drive API** for that project.
+3. Create a **Service Account** (IAM & Admin → Service Accounts → Create).
+4. Generate a JSON key for the service account and download it.
+5. Share your target Google Drive folder with the service account's email
+   address (give it **Editor** access).
+6. Copy the folder ID from the Drive URL:
+       https://drive.google.com/drive/folders/<FOLDER_ID>
+
+Environment variables
+---------------------
+GOOGLE_SERVICE_ACCOUNT_KEY
+    Either the path to the downloaded JSON key file, or the raw JSON content
+    of the key (useful for CI where storing a file is inconvenient).
+
+GOOGLE_DRIVE_FOLDER_ID
+    The ID of the Drive folder to upload files into.
+"""
+
+import json
+import os
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+_SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+
+
+def _get_service():
+    """Build and return an authenticated Drive API service."""
+    raw = os.environ.get("GOOGLE_SERVICE_ACCOUNT_KEY", "")
+    if not raw:
+        raise EnvironmentError("GOOGLE_SERVICE_ACCOUNT_KEY is not set")
+
+    # Accept either a file path or inline JSON
+    if os.path.isfile(raw):
+        with open(raw, encoding="utf-8") as fh:
+            key_data = json.load(fh)
+    else:
+        key_data = json.loads(raw)
+
+    creds = service_account.Credentials.from_service_account_info(key_data, scopes=_SCOPES)
+    return build("drive", "v3", credentials=creds)
+
+
+def upload_logs(folder_id: str, *file_paths: str) -> list:
+    """
+    Upload one or more files to a Google Drive folder.
+
+    If a file with the same name already exists in the folder it is replaced
+    (updated) rather than creating a duplicate.
+
+    Args:
+        folder_id: Google Drive folder ID to upload into.
+        *file_paths: Absolute or relative paths of local files to upload.
+
+    Returns:
+        list of dicts with keys 'name' and 'url' for each uploaded file.
+    """
+    service = _get_service()
+    results = []
+
+    for path in file_paths:
+        if not os.path.exists(path):
+            continue
+
+        name = os.path.basename(path)
+        media = MediaFileUpload(path, mimetype="text/plain", resumable=False)
+
+        # Check whether a file with this name already exists in the folder
+        existing = service.files().list(
+            q=f"name='{name}' and '{folder_id}' in parents and trashed=false",
+            fields="files(id)",
+        ).execute().get("files", [])
+
+        if existing:
+            file_id = existing[0]["id"]
+            service.files().update(fileId=file_id, media_body=media).execute()
+        else:
+            file_meta = service.files().create(
+                body={"name": name, "parents": [folder_id]},
+                media_body=media,
+                fields="id",
+            ).execute()
+            file_id = file_meta["id"]
+
+        url = f"https://drive.google.com/file/d/{file_id}/view"
+        results.append({"name": name, "url": url})
+        print(f"  Uploaded {name} → {url}")
+
+    return results
+
+
+def maybe_upload_logs(*file_paths: str) -> list:
+    """
+    Upload logs to Drive when credentials are configured; silently skip otherwise.
+
+    Args:
+        *file_paths: Paths of log files to upload.
+
+    Returns:
+        List of dicts with 'name' and 'url', or empty list if Drive is not
+        configured or the upload fails.
+    """
+    folder_id = os.environ.get("GOOGLE_DRIVE_FOLDER_ID", "")
+    if not folder_id or not os.environ.get("GOOGLE_SERVICE_ACCOUNT_KEY", ""):
+        return []
+    try:
+        return upload_logs(folder_id, *file_paths)
+    except Exception as exc:
+        print(f"Google Drive upload skipped: {exc}")
+        return []

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,2 +1,5 @@
 flask
 praw
+google-api-python-client
+google-auth
+google-auth-httplib2

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -572,7 +572,13 @@
         msg += ` ${result.errors.length} error(s) — check console.`;
         console.error('Deletion errors:', result.errors);
       }
-      toast(result.errors && result.errors.length ? 'error' : 'success', msg);
+      const hasErrors = result.errors && result.errors.length > 0;
+      toast(hasErrors ? 'error' : 'success', msg);
+
+      // Show Drive links if the server uploaded the logs
+      if (result.drive_links && result.drive_links.length > 0) {
+        result.drive_links.forEach(link => showDriveLink(link.name, link.url));
+      }
     } catch (e) {
       toast('error', 'Delete failed: ' + e.message);
     } finally {
@@ -610,6 +616,21 @@
     el.textContent = msg;
     clearTimeout(toastTimer);
     toastTimer = setTimeout(() => el.classList.remove('show'), 4000);
+  }
+
+  function showDriveLink(name, url) {
+    let panel = document.getElementById('drive-panel');
+    if (!panel) {
+      panel = document.createElement('div');
+      panel.id = 'drive-panel';
+      panel.style.cssText = 'position:fixed;bottom:5rem;right:1.5rem;background:var(--surface);border:1px solid var(--positive);border-radius:6px;padding:0.75rem 1rem;font-size:0.8rem;z-index:300;max-width:280px;';
+      panel.innerHTML = '<div style="color:var(--positive);font-weight:700;margin-bottom:0.4rem">Logs saved to Drive</div><ul id="drive-links" style="list-style:none;padding:0;margin:0;"></ul>';
+      document.body.appendChild(panel);
+    }
+    const li = document.createElement('li');
+    li.innerHTML = `<a href="${url}" target="_blank" rel="noopener" style="color:var(--accent)">${esc(name)}</a>`;
+    document.getElementById('drive-links').appendChild(li);
+    setTimeout(() => { panel = document.getElementById('drive-panel'); if (panel) panel.remove(); }, 12000);
   }
 
   function esc(str) {


### PR DESCRIPTION
## Summary

Adds optional Google Drive upload of deletion logs to the **web dashboard** and **CLI scripts**.

### New file: `drive_upload.py`
Shared helper module. Uses a Google service account to upload `deleted_comments.txt` / `deleted_posts.txt` to a Drive folder. Files are updated in-place — no duplicates created. Fully opt-in via two env vars; `maybe_upload_logs()` is a silent no-op when they are not set.

### `web/app.py`
- Adds `drive_upload` import (via `sys.path` from repo root)
- `/api/delete` calls `maybe_upload_logs()` after deletion and includes `drive_links` in the JSON response

### `web/templates/dashboard.html`
- New `showDriveLink()` function renders a temporary panel (auto-hides after 12 s) with clickable links to the uploaded files in Drive

### `web/requirements.txt`
Adds `google-api-python-client`, `google-auth`, `google-auth-httplib2`

### CLI scripts
- `commentCleaner.py`: calls `maybe_upload_logs()` after each successful deletion batch
- `PostCleaner.py`: calls `maybe_upload_logs()` after `delete_old_posts` completes

## Setup

Set two env vars (or leave unset to skip Drive entirely):


See `drive_upload.py` module docstring for full one-time setup steps.

## Test plan

- [ ] Set env vars, run `commentCleaner.py`, confirm log appears/updates in the Drive folder
- [ ] Open web app, delete items, confirm the Drive link panel appears with correct URLs
- [ ] Run without env vars set; confirm all scripts work normally with no errors or warnings