### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ deleted_posts.txt
 __pycache__/
 *.py[cod]
 *.pyo
+
+# Flask session / instance folder
+instance/
+flask_session/


### PR DESCRIPTION
## Summary

Adds a `.gitignore` to prevent accidental commits of sensitive and generated files:

- `Credentials.txt` — Reddit API secrets (client ID, secret, password)
- `deleted_comments.txt` / `deleted_posts.txt` — runtime-generated user data logs
- `__pycache__/`, `*.pyc`, `*.pyo` — Python bytecode caches
- `instance/`, `flask_session/` — Flask runtime directories

Neither file was tracked by git previously, leaving them exposed to `git add .`.

## Test plan

- [ ] Confirm `git status` no longer lists `Credentials.txt` as untracked after creating it
- [ ] Confirm deletion log files are ignored