### PR TITLE
Add weekly automated cleanup via GitHub Actions

### DIFF
--- a/.github/workflows/weekly-cleanup.yml
+++ b/.github/workflows/weekly-cleanup.yml
@@ -1,0 +1,43 @@
+name: Weekly Reddit Cleanup
+
+on:
+  schedule:
+    # Every Sunday at 00:00 UTC
+    - cron: '0 0 * * 0'
+  # Allow triggering manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install praw
+
+      - name: Run weekly cleanup (score < 1)
+        env:
+          REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
+          REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
+          REDDIT_USERNAME: ${{ secrets.REDDIT_USERNAME }}
+          REDDIT_PASSWORD: ${{ secrets.REDDIT_PASSWORD }}
+        run: python weekly_cleanup.py
+
+      - name: Upload deletion logs as artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deletion-logs-${{ github.run_number }}
+          path: |
+            deleted_comments.txt
+            deleted_posts.txt
+          if-no-files-found: ignore
+          retention-days: 90

--- a/weekly_cleanup.py
+++ b/weekly_cleanup.py
@@ -1,0 +1,74 @@
+"""
+Weekly automated cleanup script for GitHub Actions.
+
+Reads credentials from environment variables and deletes all comments
+and posts with a score < 1, archiving each to a log file first.
+
+Required environment variables:
+    REDDIT_CLIENT_ID
+    REDDIT_CLIENT_SECRET
+    REDDIT_USERNAME
+    REDDIT_PASSWORD
+"""
+
+import os
+from datetime import datetime
+
+import praw
+
+
+def main():
+    reddit = praw.Reddit(
+        client_id=os.environ["REDDIT_CLIENT_ID"],
+        client_secret=os.environ["REDDIT_CLIENT_SECRET"],
+        username=os.environ["REDDIT_USERNAME"],
+        password=os.environ["REDDIT_PASSWORD"],
+        user_agent="commentCleaner",
+        validate_on_submit=True,
+    )
+
+    username = os.environ["REDDIT_USERNAME"]
+    print(f"Authenticated as: {reddit.user.me()}")
+    print(f"Criteria: score < 1\n")
+
+    # ── Comments ──────────────────────────────────────────────────────────
+    comments_deleted = 0
+    print("Scanning comments…")
+    for comment in reddit.redditor(username).comments.new(limit=None):
+        if comment.score < 1:
+            date_str = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%d %H:%M:%S")
+            with open("deleted_comments.txt", "a", encoding="utf-8") as f:
+                f.write(f"{date_str} | {comment.score} | {comment.body}\n")
+            try:
+                comment.edit(".")
+                comment.delete()
+                comments_deleted += 1
+                print(f"  Deleted comment ({comment.score}) in r/{comment.subreddit}")
+            except praw.exceptions.APIException as e:
+                print(f"  Error deleting comment {comment.id}: {e}")
+
+    # ── Posts ─────────────────────────────────────────────────────────────
+    posts_deleted = 0
+    print("\nScanning posts…")
+    for submission in reddit.redditor(username).submissions.new(limit=None):
+        if submission.score < 1:
+            with open("deleted_posts.txt", "a", encoding="utf-8") as f:
+                f.write(
+                    f"{submission.title}, "
+                    f"{datetime.utcfromtimestamp(submission.created_utc)}, "
+                    f"{submission.score}, "
+                    f"{submission.subreddit.display_name}\n"
+                )
+            try:
+                submission.edit(".")
+                submission.delete()
+                posts_deleted += 1
+                print(f"  Deleted post '{submission.title}' ({submission.score}) in r/{submission.subreddit}")
+            except praw.exceptions.APIException as e:
+                print(f"  Error deleting post {submission.id}: {e}")
+
+    print(f"\nDone. Deleted {comments_deleted} comment(s) and {posts_deleted} post(s).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an automated weekly cleanup pipeline that deletes all comments and posts with score < 1 without any manual interaction.

### `weekly_cleanup.py`
Non-interactive script designed for CI:
- Reads all credentials from env vars (no `input()` prompts)
- Iterates all comments and posts; deletes those with `score < 1`
- Logs each deletion to `deleted_comments.txt` / `deleted_posts.txt` before deleting
- Prints a summary count at the end

### `.github/workflows/weekly-cleanup.yml`
- **Schedule:** every Sunday at 00:00 UTC
- **Manual trigger:** available via `workflow_dispatch` in the Actions tab
- Installs `praw`, runs `weekly_cleanup.py` with credentials from repository secrets
- Uploads `deleted_comments.txt` and `deleted_posts.txt` as workflow artifacts (90-day retention)

### `CLAUDE.md`
Updated to document all three usage modes (CLI, web dashboard, CI), secrets table, architecture notes, and updated repo structure.

## One-time setup

Add four repository secrets (Settings → Secrets and variables → Actions):

| Secret | Value |
|--------|-------|
| `REDDIT_CLIENT_ID` | Script app client ID |
| `REDDIT_CLIENT_SECRET` | Script app client secret |
| `REDDIT_USERNAME` | Reddit username |
| `REDDIT_PASSWORD` | Reddit password |

## Test plan

- [ ] Trigger the workflow manually from the Actions tab with secrets configured
- [ ] Verify the run log shows correct deletions and the artifact contains the log files
- [ ] Confirm the workflow does not error when there are no items to delete