### PR TITLE
Use FLASK_SECRET_KEY env var to persist sessions across restarts

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -6,7 +6,7 @@ import praw
 from flask import Flask, jsonify, redirect, render_template, request, session, url_for
 
 app = Flask(__name__)
-app.secret_key = os.urandom(24)
+app.secret_key = os.environ.get("FLASK_SECRET_KEY") or os.urandom(24)
 
 # Log files are kept at the repo root, not inside web/
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
## Summary

-  on startup regenerates the secret key on every restart, immediately invalidating all browser sessions
- Now reads  from the environment; falls back to  for zero-config local dev

## Setup
Add to your server environment (or  file):

Generate one with: 9271e69500f4b419e5c5f925725fa8d875efbd1142108850320e7684b9bcddd7

## Test plan
- [x] Set , start the app, log in, restart the app — confirm session is preserved
- [x] Without  set, confirm the app still starts normally

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d