### PR TITLE
Add Android app with Reddit OAuth (PKCE) and full dashboard

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,11 @@
+*.iml
+.gradle/
+.idea/
+/local.properties
+/.DS_Store
+/build/
+/captures/
+.externalNativeBuild/
+.cxx/
+app/build/
+app/release/

--- a/android/SETUP.md
+++ b/android/SETUP.md
@@ -1,0 +1,98 @@
+# Android App — Setup Guide
+
+## Prerequisites
+
+- Android Studio Hedgehog (2023.1) or newer
+- JDK 17
+- A Reddit account with a registered **installed app**
+
+---
+
+## 1. Register a Reddit "installed app"
+
+1. Go to <https://www.reddit.com/prefs/apps>
+2. Click **Create another app…**
+3. Choose type **installed app** (not "script")
+4. Set **redirect URI** to exactly: `redditcommentcleaner://auth`
+5. Save — note the **client ID** (the string under your app name)
+
+---
+
+## 2. Put your client ID in the build config
+
+Open `app/build.gradle` and replace `YOUR_CLIENT_ID`:
+
+```groovy
+buildConfigField "String", "REDDIT_CLIENT_ID", '"abc123xyz"'   // ← your client ID here
+```
+
+---
+
+## 3. Build & run
+
+```bash
+cd android
+./gradlew assembleDebug
+# install on connected device / emulator:
+adb install app/build/outputs/apk/debug/app-debug.apk
+```
+
+Or open the `android/` directory in Android Studio and click **Run**.
+
+---
+
+## How the app works
+
+| Step | What happens |
+|------|--------------|
+| First launch | Routed to the Login screen |
+| Tap "Login with Reddit" | Reddit's OAuth consent page opens in a Chrome Custom Tab |
+| User approves | Reddit redirects to `redditcommentcleaner://auth?code=…` |
+| App exchanges code for token | PKCE S256 flow; tokens stored in EncryptedSharedPreferences |
+| Dashboard loads | All comments and posts fetched with full pagination |
+| Filter + select | Score ≤ N, age ≥ N days; Select All / None / Matching |
+| Delete | Each item is edited to `"."` then deleted; progress shown inline |
+| Logout | Tokens cleared; back to Login screen |
+
+---
+
+## OAuth scopes requested
+
+| Scope | Purpose |
+|-------|---------|
+| `identity` | Read username |
+| `history`  | List comments and posts |
+| `edit`     | Overwrite item body with `"."` |
+| `vote`     | (reserved for future score filtering) |
+
+---
+
+## Project structure
+
+```
+android/
+├── app/build.gradle               ← dependencies & buildConfigFields
+├── app/src/main/
+│   ├── AndroidManifest.xml
+│   ├── java/com/redditcommentcleaner/
+│   │   ├── MainActivity.kt        ← routes to Login or Dashboard
+│   │   ├── auth/
+│   │   │   ├── LoginActivity.kt   ← opens OAuth URL in Chrome Custom Tab
+│   │   │   └── OAuthCallbackActivity.kt  ← handles redirect, exchanges code
+│   │   ├── api/
+│   │   │   ├── RedditApiClient.kt ← OkHttp/Retrofit setup + token refresh
+│   │   │   ├── RedditAuthService.kt  ← token exchange endpoints
+│   │   │   └── RedditApiService.kt   ← comments, posts, edit, delete
+│   │   ├── model/RedditModels.kt  ← data classes
+│   │   ├── dashboard/
+│   │   │   ├── DashboardActivity.kt  ← main screen
+│   │   │   ├── DashboardViewModel.kt ← load, filter, delete logic
+│   │   │   └── ItemAdapter.kt     ← RecyclerView adapter
+│   │   └── util/
+│   │       ├── TokenStorage.kt    ← EncryptedSharedPreferences wrapper
+│   │       └── PkceHelper.kt      ← PKCE code_verifier/challenge generation
+│   └── res/
+│       ├── layout/                ← activity and item layouts
+│       └── values/                ← colors, strings, themes
+└── SETUP.md                       ← this file
+```

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,57 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    namespace 'com.redditcommentcleaner'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.redditcommentcleaner"
+        minSdk 26
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+
+        // Replace YOUR_CLIENT_ID with the client_id from your Reddit "installed app"
+        buildConfigField "String", "REDDIT_CLIENT_ID", '"YOUR_CLIENT_ID"'
+        buildConfigField "String", "REDIRECT_URI", '"redditcommentcleaner://auth"'
+        buildConfigField "String", "OAUTH_SCOPES", '"identity history edit vote"'
+    }
+
+    buildFeatures {
+        viewBinding true
+        buildConfig true
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.activity:activity-ktx:1.8.2'
+    implementation 'androidx.fragment:fragment-ktx:1.6.2'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.7.0'
+    implementation 'androidx.security:security-crypto:1.1.0-alpha06'
+    implementation 'androidx.browser:browser:1.7.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
+
+    implementation 'com.google.code.gson:gson:2.10.1'
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.RedditCommentCleaner">
+
+        <!-- Entry point: routes to Login or Dashboard based on token presence -->
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".auth.LoginActivity"
+            android:exported="false" />
+
+        <!-- Receives the OAuth redirect URI redditcommentcleaner://auth?code=... -->
+        <activity
+            android:name=".auth.OAuthCallbackActivity"
+            android:exported="true"
+            android:launchMode="singleTop">
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="redditcommentcleaner"
+                    android:host="auth" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".dashboard.DashboardActivity"
+            android:exported="false" />
+
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/redditcommentcleaner/MainActivity.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/MainActivity.kt
@@ -1,0 +1,23 @@
+package com.redditcommentcleaner
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.redditcommentcleaner.auth.LoginActivity
+import com.redditcommentcleaner.dashboard.DashboardActivity
+import com.redditcommentcleaner.util.TokenStorage
+
+/** Routes to Login or Dashboard depending on stored token. */
+class MainActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val next = if (TokenStorage(this).isLoggedIn()) {
+            Intent(this, DashboardActivity::class.java)
+        } else {
+            Intent(this, LoginActivity::class.java)
+        }
+        startActivity(next)
+        finish()
+    }
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/api/RedditApiClient.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/api/RedditApiClient.kt
@@ -1,0 +1,81 @@
+package com.redditcommentcleaner.api
+
+import android.content.Context
+import android.util.Base64
+import com.redditcommentcleaner.BuildConfig
+import com.redditcommentcleaner.util.TokenStorage
+import kotlinx.coroutines.runBlocking
+import okhttp3.Credentials
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+private const val BASE_URL      = "https://oauth.reddit.com/"
+private const val AUTH_BASE_URL = "https://www.reddit.com/"
+
+object RedditApiClient {
+
+    /** Retrofit for authenticated API calls (oauth.reddit.com). */
+    fun apiService(context: Context): RedditApiService {
+        val tokenStorage = TokenStorage(context)
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                // Refresh token if near expiry
+                if (tokenStorage.isTokenExpired() && !tokenStorage.refreshToken.isNullOrBlank()) {
+                    runBlocking {
+                        runCatching {
+                            val resp = authService().refreshToken(
+                                refreshToken = tokenStorage.refreshToken!!
+                            )
+                            tokenStorage.accessToken  = resp.accessToken
+                            tokenStorage.tokenExpiryMs = System.currentTimeMillis() + resp.expiresIn * 1000L
+                        }
+                    }
+                }
+                val request = chain.request().newBuilder()
+                    .header("Authorization", "Bearer ${tokenStorage.accessToken}")
+                    .header("User-Agent", userAgent(tokenStorage.username ?: "unknown"))
+                    .build()
+                chain.proceed(request)
+            }
+            .addInterceptor(loggingInterceptor())
+            .build()
+
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(RedditApiService::class.java)
+    }
+
+    /** Retrofit for token exchange (www.reddit.com) — uses HTTP Basic auth. */
+    fun authService(): RedditAuthService {
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val credential = Credentials.basic(BuildConfig.REDDIT_CLIENT_ID, "")
+                val request = chain.request().newBuilder()
+                    .header("Authorization", credential)
+                    .header("User-Agent", userAgent("anonymous"))
+                    .build()
+                chain.proceed(request)
+            }
+            .addInterceptor(loggingInterceptor())
+            .build()
+
+        return Retrofit.Builder()
+            .baseUrl(AUTH_BASE_URL)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(RedditAuthService::class.java)
+    }
+
+    private fun userAgent(username: String) =
+        "android:com.redditcommentcleaner:v1.0 (by /u/$username)"
+
+    private fun loggingInterceptor() = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BASIC
+    }
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/api/RedditApiService.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/api/RedditApiService.kt
@@ -1,0 +1,46 @@
+package com.redditcommentcleaner.api
+
+import com.redditcommentcleaner.model.CommentData
+import com.redditcommentcleaner.model.ListingChild
+import com.redditcommentcleaner.model.MeResponse
+import com.redditcommentcleaner.model.PostData
+import com.redditcommentcleaner.model.RedditListingResponse
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface RedditApiService {
+
+    @GET("api/v1/me")
+    suspend fun getMe(): MeResponse
+
+    @GET("user/{username}/comments")
+    suspend fun getComments(
+        @Path("username") username: String,
+        @Query("limit")   limit: Int = 100,
+        @Query("after")   after: String? = null
+    ): RedditListingResponse<CommentData>
+
+    @GET("user/{username}/submitted")
+    suspend fun getPosts(
+        @Path("username") username: String,
+        @Query("limit")   limit: Int = 100,
+        @Query("after")   after: String? = null
+    ): RedditListingResponse<PostData>
+
+    @FormUrlEncoded
+    @POST("api/editusertext")
+    suspend fun editItem(
+        @Field("thing_id") thingId: String,
+        @Field("text")     text: String = "."
+    ): Any
+
+    @FormUrlEncoded
+    @POST("api/del")
+    suspend fun deleteItem(
+        @Field("id") fullname: String
+    ): Any
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/api/RedditAuthService.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/api/RedditAuthService.kt
@@ -1,0 +1,27 @@
+package com.redditcommentcleaner.api
+
+import com.redditcommentcleaner.model.TokenResponse
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+
+interface RedditAuthService {
+
+    /** Exchange an authorization code for tokens (PKCE flow). */
+    @FormUrlEncoded
+    @POST("api/v1/access_token")
+    suspend fun fetchToken(
+        @Field("grant_type")    grantType: String = "authorization_code",
+        @Field("code")          code: String,
+        @Field("redirect_uri")  redirectUri: String,
+        @Field("code_verifier") codeVerifier: String
+    ): TokenResponse
+
+    /** Exchange a refresh token for a new access token. */
+    @FormUrlEncoded
+    @POST("api/v1/access_token")
+    suspend fun refreshToken(
+        @Field("grant_type")    grantType: String = "refresh_token",
+        @Field("refresh_token") refreshToken: String
+    ): TokenResponse
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/auth/LoginActivity.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/auth/LoginActivity.kt
@@ -1,0 +1,61 @@
+package com.redditcommentcleaner.auth
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabsIntent
+import com.redditcommentcleaner.BuildConfig
+import com.redditcommentcleaner.databinding.ActivityLoginBinding
+import com.redditcommentcleaner.util.PkceHelper
+
+/**
+ * Shows a "Login with Reddit" button that opens Reddit's OAuth consent page
+ * in a Chrome Custom Tab. The redirect is caught by OAuthCallbackActivity.
+ *
+ * The PKCE code_verifier is stored in a companion object so OAuthCallbackActivity
+ * can retrieve it for the token exchange.
+ */
+class LoginActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityLoginBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityLoginBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        supportActionBar?.hide()
+
+        binding.btnLogin.setOnClickListener { openRedditAuth() }
+    }
+
+    private fun openRedditAuth() {
+        val verifier  = PkceHelper.generateCodeVerifier()
+        val challenge = PkceHelper.generateCodeChallenge(verifier)
+        val state     = PkceHelper.generateState()
+
+        pendingCodeVerifier = verifier
+        pendingState        = state
+
+        val url = Uri.Builder()
+            .scheme("https").authority("www.reddit.com")
+            .path("api/v1/authorize")
+            .appendQueryParameter("client_id",             BuildConfig.REDDIT_CLIENT_ID)
+            .appendQueryParameter("response_type",         "code")
+            .appendQueryParameter("state",                 state)
+            .appendQueryParameter("redirect_uri",          BuildConfig.REDIRECT_URI)
+            .appendQueryParameter("duration",              "permanent")
+            .appendQueryParameter("scope",                 BuildConfig.OAUTH_SCOPES)
+            .appendQueryParameter("code_challenge",        challenge)
+            .appendQueryParameter("code_challenge_method", "S256")
+            .build()
+
+        CustomTabsIntent.Builder().build().launchUrl(this, url)
+    }
+
+    companion object {
+        /** Shared with OAuthCallbackActivity — lives only for the duration of the login flow. */
+        var pendingCodeVerifier: String? = null
+        var pendingState: String?        = null
+    }
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/auth/OAuthCallbackActivity.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/auth/OAuthCallbackActivity.kt
@@ -1,0 +1,98 @@
+package com.redditcommentcleaner.auth
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.redditcommentcleaner.BuildConfig
+import com.redditcommentcleaner.api.RedditApiClient
+import com.redditcommentcleaner.dashboard.DashboardActivity
+import com.redditcommentcleaner.databinding.ActivityOauthCallbackBinding
+import com.redditcommentcleaner.util.TokenStorage
+import kotlinx.coroutines.launch
+
+/**
+ * Transparent activity that intercepts the OAuth redirect URI
+ * (redditcommentcleaner://auth?code=...&state=...).
+ *
+ * 1. Validates the state parameter.
+ * 2. Exchanges the code for tokens.
+ * 3. Fetches the authenticated user's username.
+ * 4. Stores everything and launches DashboardActivity.
+ */
+class OAuthCallbackActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityOauthCallbackBinding
+    private lateinit var tokenStorage: TokenStorage
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityOauthCallbackBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        supportActionBar?.hide()
+
+        tokenStorage = TokenStorage(this)
+        handleIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent?.let { handleIntent(it) }
+    }
+
+    private fun handleIntent(intent: Intent) {
+        val uri = intent.data ?: return finish()
+
+        val error = uri.getQueryParameter("error")
+        if (error != null) {
+            toast("Reddit OAuth error: $error")
+            goToLogin()
+            return
+        }
+
+        val code  = uri.getQueryParameter("code")  ?: run { goToLogin(); return }
+        val state = uri.getQueryParameter("state") ?: run { goToLogin(); return }
+
+        if (state != LoginActivity.pendingState) {
+            toast("OAuth state mismatch — possible CSRF attack")
+            goToLogin()
+            return
+        }
+
+        val verifier = LoginActivity.pendingCodeVerifier ?: run { goToLogin(); return }
+        LoginActivity.pendingCodeVerifier = null
+        LoginActivity.pendingState = null
+
+        lifecycleScope.launch {
+            runCatching {
+                val authService = RedditApiClient.authService()
+                val tokenResp = authService.fetchToken(
+                    code         = code,
+                    redirectUri  = BuildConfig.REDIRECT_URI,
+                    codeVerifier = verifier
+                )
+                tokenStorage.accessToken   = tokenResp.accessToken
+                tokenStorage.refreshToken  = tokenResp.refreshToken
+                tokenStorage.tokenExpiryMs = System.currentTimeMillis() + tokenResp.expiresIn * 1000L
+
+                // Fetch and store the username
+                val me = RedditApiClient.apiService(this@OAuthCallbackActivity).getMe()
+                tokenStorage.username = me.name
+
+                startActivity(Intent(this@OAuthCallbackActivity, DashboardActivity::class.java))
+                finish()
+            }.onFailure {
+                toast("Login failed: ${it.message}")
+                goToLogin()
+            }
+        }
+    }
+
+    private fun goToLogin() {
+        startActivity(Intent(this, LoginActivity::class.java))
+        finish()
+    }
+
+    private fun toast(msg: String) = Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/dashboard/DashboardActivity.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/dashboard/DashboardActivity.kt
@@ -1,0 +1,162 @@
+package com.redditcommentcleaner.dashboard
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.tabs.TabLayout
+import com.redditcommentcleaner.auth.LoginActivity
+import com.redditcommentcleaner.databinding.ActivityDashboardBinding
+import com.redditcommentcleaner.model.RedditItem
+
+class DashboardActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityDashboardBinding
+    private lateinit var commentAdapter: ItemAdapter
+    private lateinit var postAdapter: ItemAdapter
+
+    private val vm: DashboardViewModel by viewModels {
+        object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(cls: Class<T>) =
+                DashboardViewModel(applicationContext) as T
+        }
+    }
+
+    private val currentType get() =
+        if (binding.tabLayout.selectedTabPosition == 0) DashboardViewModel.ItemType.COMMENT
+        else DashboardViewModel.ItemType.POST
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityDashboardBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setupRecyclerViews()
+        setupTabs()
+        setupButtons()
+        observeViewModel()
+
+        vm.loadAll()
+    }
+
+    // ── Setup ────────────────────────────────────────────────────────────────
+
+    private fun setupRecyclerViews() {
+        commentAdapter = ItemAdapter { updateDeleteButtonLabel() }
+        postAdapter    = ItemAdapter { updateDeleteButtonLabel() }
+        binding.rvComments.adapter = commentAdapter
+        binding.rvPosts.adapter    = postAdapter
+    }
+
+    private fun setupTabs() {
+        binding.tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                binding.rvComments.visibility = if (tab.position == 0) View.VISIBLE else View.GONE
+                binding.rvPosts.visibility    = if (tab.position == 1) View.VISIBLE else View.GONE
+                updateDeleteButtonLabel()
+            }
+            override fun onTabUnselected(tab: TabLayout.Tab?) = Unit
+            override fun onTabReselected(tab: TabLayout.Tab?) = Unit
+        })
+    }
+
+    private fun setupButtons() {
+        binding.btnLoad.setOnClickListener { vm.loadAll() }
+
+        binding.btnSelectAll.setOnClickListener  { vm.selectAll(currentType, true) }
+        binding.btnSelectNone.setOnClickListener { vm.selectAll(currentType, false) }
+
+        binding.btnSelectMatching.setOnClickListener {
+            val maxScore  = binding.etMaxScore.text.toString().toIntOrNull()  ?: 0
+            val minAgeDays= binding.etMinAge.text.toString().toLongOrNull()   ?: 0L
+            vm.selectMatching(currentType, maxScore, minAgeDays)
+        }
+
+        binding.btnDelete.setOnClickListener { confirmDelete() }
+
+        binding.btnLogout.setOnClickListener {
+            vm.logout()
+            startActivity(Intent(this, LoginActivity::class.java))
+            finish()
+        }
+    }
+
+    // ── Observe ──────────────────────────────────────────────────────────────
+
+    private fun observeViewModel() {
+        vm.comments.observe(this) { items ->
+            commentAdapter.submitList(items.toList())
+            binding.tabLayout.getTabAt(0)?.text = "Comments (${items.size})"
+            updateDeleteButtonLabel()
+        }
+        vm.posts.observe(this) { items ->
+            postAdapter.submitList(items.toList())
+            binding.tabLayout.getTabAt(1)?.text = "Posts (${items.size})"
+            updateDeleteButtonLabel()
+        }
+        vm.uiState.observe(this) { state ->
+            when (state) {
+                is UiState.Loading -> showLoading(true)
+                is UiState.Idle    -> showLoading(false)
+                is UiState.Error   -> { showLoading(false); toast(state.message) }
+                is UiState.DeleteProgress -> {
+                    binding.progressBar.visibility = View.VISIBLE
+                    binding.progressBar.progress   = (state.done * 100 / state.total.coerceAtLeast(1))
+                    binding.tvStatus.text = "Deleting ${state.done}/${state.total}…"
+                }
+                is UiState.DeleteDone -> {
+                    binding.progressBar.visibility = View.GONE
+                    binding.tvStatus.text          = ""
+                    toast("Done!")
+                }
+            }
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun updateDeleteButtonLabel() {
+        val count = when (currentType) {
+            DashboardViewModel.ItemType.COMMENT ->
+                vm.comments.value.orEmpty().count { it.selected }
+            DashboardViewModel.ItemType.POST    ->
+                vm.posts.value.orEmpty().count { it.selected }
+        }
+        binding.btnDelete.text = if (count > 0) "Delete Selected ($count)" else "Delete Selected"
+        binding.btnDelete.isEnabled = count > 0
+    }
+
+    private fun showLoading(loading: Boolean) {
+        binding.progressBar.visibility = if (loading) View.VISIBLE else View.GONE
+        binding.tvStatus.text          = if (loading) "Loading…" else ""
+    }
+
+    private fun confirmDelete() {
+        val commentCount = vm.comments.value.orEmpty().count { it.selected }
+        val postCount    = vm.posts.value.orEmpty().count { it.selected }
+        val total        = commentCount + postCount
+        if (total == 0) return
+
+        AlertDialog.Builder(this)
+            .setTitle("Confirm Deletion")
+            .setMessage(
+                buildString {
+                    append("You are about to permanently delete:\n")
+                    if (commentCount > 0) append("  • $commentCount comment(s)\n")
+                    if (postCount    > 0) append("  • $postCount post(s)\n")
+                    append("\nThis cannot be undone.")
+                }
+            )
+            .setPositiveButton("Delete") { _, _ -> vm.deleteSelected() }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun toast(msg: String) = Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/dashboard/DashboardViewModel.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/dashboard/DashboardViewModel.kt
@@ -1,0 +1,137 @@
+package com.redditcommentcleaner.dashboard
+
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.redditcommentcleaner.api.RedditApiClient
+import com.redditcommentcleaner.model.CommentData
+import com.redditcommentcleaner.model.PostData
+import com.redditcommentcleaner.model.RedditItem
+import com.redditcommentcleaner.util.TokenStorage
+import kotlinx.coroutines.launch
+
+sealed class UiState {
+    object Loading : UiState()
+    object Idle    : UiState()
+    data class Error(val message: String) : UiState()
+    data class DeleteProgress(val done: Int, val total: Int) : UiState()
+    object DeleteDone : UiState()
+}
+
+class DashboardViewModel(private val context: Context) : ViewModel() {
+
+    private val api     by lazy { RedditApiClient.apiService(context) }
+    private val storage by lazy { TokenStorage(context) }
+
+    private val _comments  = MutableLiveData<List<RedditItem.Comment>>(emptyList())
+    val comments: LiveData<List<RedditItem.Comment>> = _comments
+
+    private val _posts     = MutableLiveData<List<RedditItem.Post>>(emptyList())
+    val posts: LiveData<List<RedditItem.Post>> = _posts
+
+    private val _uiState   = MutableLiveData<UiState>(UiState.Idle)
+    val uiState: LiveData<UiState> = _uiState
+
+    val username: String? get() = storage.username
+
+    // ── Load all items ────────────────────────────────────────────────────────
+
+    fun loadAll() {
+        _uiState.value = UiState.Loading
+        viewModelScope.launch {
+            runCatching {
+                val username = storage.username ?: error("Not logged in")
+                _comments.postValue(fetchAllComments(username))
+                _posts.postValue(fetchAllPosts(username))
+                _uiState.postValue(UiState.Idle)
+            }.onFailure {
+                _uiState.postValue(UiState.Error(it.message ?: "Unknown error"))
+            }
+        }
+    }
+
+    private suspend fun fetchAllComments(username: String): List<RedditItem.Comment> {
+        val result = mutableListOf<CommentData>()
+        var after: String? = null
+        do {
+            val page = api.getComments(username, after = after)
+            result.addAll(page.data.children.map { it.data })
+            after = page.data.after
+        } while (after != null)
+        return result.map { RedditItem.Comment(it) }
+    }
+
+    private suspend fun fetchAllPosts(username: String): List<RedditItem.Post> {
+        val result = mutableListOf<PostData>()
+        var after: String? = null
+        do {
+            val page = api.getPosts(username, after = after)
+            result.addAll(page.data.children.map { it.data })
+            after = page.data.after
+        } while (after != null)
+        return result.map { RedditItem.Post(it) }
+    }
+
+    // ── Delete selected ───────────────────────────────────────────────────────
+
+    fun deleteSelected() {
+        val selectedComments = _comments.value.orEmpty().filter { it.selected }
+        val selectedPosts    = _posts.value.orEmpty().filter { it.selected }
+        val total            = selectedComments.size + selectedPosts.size
+        if (total == 0) return
+
+        _uiState.value = UiState.DeleteProgress(0, total)
+        viewModelScope.launch {
+            var done = 0
+            runCatching {
+                for (item in selectedComments) {
+                    runCatching { api.editItem(item.data.name) }
+                    api.deleteItem(item.data.name)
+                    done++
+                    _uiState.postValue(UiState.DeleteProgress(done, total))
+                }
+                for (item in selectedPosts) {
+                    // Only self-posts can be edited; link posts can still be deleted
+                    if (item.data.isSelf) runCatching { api.editItem(item.data.name) }
+                    api.deleteItem(item.data.name)
+                    done++
+                    _uiState.postValue(UiState.DeleteProgress(done, total))
+                }
+                // Remove deleted items from lists
+                _comments.postValue(_comments.value.orEmpty().filterNot { it.selected })
+                _posts.postValue(_posts.value.orEmpty().filterNot { it.selected })
+                _uiState.postValue(UiState.DeleteDone)
+            }.onFailure {
+                _uiState.postValue(UiState.Error("Delete failed: ${it.message}"))
+            }
+        }
+    }
+
+    // ── Selection helpers ─────────────────────────────────────────────────────
+
+    fun selectAll(type: ItemType, selected: Boolean) {
+        when (type) {
+            ItemType.COMMENT -> _comments.value = _comments.value.orEmpty().map { it.copy(selected = selected) }
+            ItemType.POST    -> _posts.value    = _posts.value.orEmpty().map { it.copy(selected = selected) }
+        }
+    }
+
+    fun selectMatching(type: ItemType, maxScore: Int, minAgeDays: Long) {
+        when (type) {
+            ItemType.COMMENT -> _comments.value = _comments.value.orEmpty().map {
+                it.copy(selected = it.score <= maxScore && it.ageDays >= minAgeDays)
+            }
+            ItemType.POST -> _posts.value = _posts.value.orEmpty().map {
+                it.copy(selected = it.score <= maxScore && it.ageDays >= minAgeDays)
+            }
+        }
+    }
+
+    fun logout() {
+        storage.clear()
+    }
+
+    enum class ItemType { COMMENT, POST }
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/dashboard/ItemAdapter.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/dashboard/ItemAdapter.kt
@@ -1,0 +1,60 @@
+package com.redditcommentcleaner.dashboard
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.redditcommentcleaner.databinding.ItemRedditRowBinding
+import com.redditcommentcleaner.model.RedditItem
+
+class ItemAdapter(
+    private val onSelectionChanged: () -> Unit
+) : ListAdapter<RedditItem, ItemAdapter.ViewHolder>(DiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemRedditRowBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class ViewHolder(private val b: ItemRedditRowBinding) : RecyclerView.ViewHolder(b.root) {
+        fun bind(item: RedditItem) {
+            b.checkBox.isChecked = item.selected
+            b.tvSubreddit.text   = "r/${item.subreddit}"
+            b.tvScore.text       = "↑ ${item.score}"
+            b.tvAge.text         = "${item.ageDays}d"
+
+            when (item) {
+                is RedditItem.Comment -> {
+                    b.tvType.text    = "Comment"
+                    b.tvContent.text = item.data.body.take(120)
+                }
+                is RedditItem.Post -> {
+                    b.tvType.text    = "Post"
+                    b.tvContent.text = item.data.title
+                }
+            }
+
+            b.checkBox.setOnCheckedChangeListener(null)
+            b.checkBox.setOnCheckedChangeListener { _, checked ->
+                item.selected = checked
+                onSelectionChanged()
+            }
+            b.root.setOnClickListener {
+                item.selected = !item.selected
+                b.checkBox.isChecked = item.selected
+                onSelectionChanged()
+            }
+        }
+    }
+
+    private class DiffCallback : DiffUtil.ItemCallback<RedditItem>() {
+        override fun areItemsTheSame(old: RedditItem, new: RedditItem) = old.name == new.name
+        override fun areContentsTheSame(old: RedditItem, new: RedditItem) =
+            old.name == new.name && old.selected == new.selected
+    }
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/model/RedditModels.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/model/RedditModels.kt
@@ -1,0 +1,89 @@
+package com.redditcommentcleaner.model
+
+import com.google.gson.annotations.SerializedName
+import java.util.concurrent.TimeUnit
+
+// ── API response wrappers ─────────────────────────────────────────────────────
+
+data class RedditListingResponse<T>(
+    val data: ListingData<T>
+)
+
+data class ListingData<T>(
+    val after: String?,
+    val children: List<ListingChild<T>>
+)
+
+data class ListingChild<T>(
+    val kind: String,
+    val data: T
+)
+
+data class MeResponse(
+    val name: String,
+    val id: String,
+    @SerializedName("icon_img") val iconImg: String?
+)
+
+data class TokenResponse(
+    @SerializedName("access_token") val accessToken: String,
+    @SerializedName("refresh_token") val refreshToken: String?,
+    @SerializedName("expires_in") val expiresIn: Int,
+    @SerializedName("token_type") val tokenType: String,
+    val scope: String
+)
+
+// ── Reddit item data classes ───────────────────────────────────────────────────
+
+data class CommentData(
+    val id: String,
+    val name: String,          // fullname e.g. "t1_abcdef"
+    val body: String,
+    val score: Int,
+    @SerializedName("created_utc") val createdUtc: Double,
+    val subreddit: String,
+    @SerializedName("link_title") val linkTitle: String?
+)
+
+data class PostData(
+    val id: String,
+    val name: String,          // fullname e.g. "t3_abcdef"
+    val title: String,
+    val score: Int,
+    @SerializedName("created_utc") val createdUtc: Double,
+    val subreddit: String,
+    @SerializedName("is_self") val isSelf: Boolean
+)
+
+// ── UI model ─────────────────────────────────────────────────────────────────
+
+sealed class RedditItem(open var selected: Boolean = false) {
+    data class Comment(val data: CommentData, override var selected: Boolean = false) : RedditItem(selected)
+    data class Post(val data: PostData, override var selected: Boolean = false) : RedditItem(selected)
+
+    val name: String get() = when (this) {
+        is Comment -> data.name
+        is Post    -> data.name
+    }
+
+    val score: Int get() = when (this) {
+        is Comment -> data.score
+        is Post    -> data.score
+    }
+
+    val createdUtc: Double get() = when (this) {
+        is Comment -> data.createdUtc
+        is Post    -> data.createdUtc
+    }
+
+    val subreddit: String get() = when (this) {
+        is Comment -> data.subreddit
+        is Post    -> data.subreddit
+    }
+
+    /** Age of the item in whole days. */
+    val ageDays: Long get() {
+        val nowSec = System.currentTimeMillis() / 1000L
+        return TimeUnit.SECONDS.toDays(nowSec - createdUtc.toLong())
+    }
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/util/PkceHelper.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/util/PkceHelper.kt
@@ -1,0 +1,29 @@
+package com.redditcommentcleaner.util
+
+import android.util.Base64
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+object PkceHelper {
+
+    /** Generates a cryptographically random code verifier (43-128 URL-safe chars). */
+    fun generateCodeVerifier(): String {
+        val bytes = ByteArray(64)
+        SecureRandom().nextBytes(bytes)
+        return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+    }
+
+    /** Derives the S256 code challenge from the code verifier. */
+    fun generateCodeChallenge(codeVerifier: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(codeVerifier.toByteArray(Charsets.US_ASCII))
+        return Base64.encodeToString(hash, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+    }
+
+    /** Generates a random state parameter to defend against CSRF. */
+    fun generateState(): String {
+        val bytes = ByteArray(16)
+        SecureRandom().nextBytes(bytes)
+        return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+    }
+}

--- a/android/app/src/main/java/com/redditcommentcleaner/util/TokenStorage.kt
+++ b/android/app/src/main/java/com/redditcommentcleaner/util/TokenStorage.kt
@@ -1,0 +1,51 @@
+package com.redditcommentcleaner.util
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Persists OAuth tokens in EncryptedSharedPreferences (AES-256-GCM key in the Android Keystore).
+ */
+class TokenStorage(context: Context) {
+
+    private val prefs = EncryptedSharedPreferences.create(
+        context,
+        "reddit_tokens",
+        MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    var accessToken: String?
+        get() = prefs.getString(KEY_ACCESS_TOKEN, null)
+        set(value) = prefs.edit().putString(KEY_ACCESS_TOKEN, value).apply()
+
+    var refreshToken: String?
+        get() = prefs.getString(KEY_REFRESH_TOKEN, null)
+        set(value) = prefs.edit().putString(KEY_REFRESH_TOKEN, value).apply()
+
+    var username: String?
+        get() = prefs.getString(KEY_USERNAME, null)
+        set(value) = prefs.edit().putString(KEY_USERNAME, value).apply()
+
+    /** Millisecond epoch at which the access token expires. */
+    var tokenExpiryMs: Long
+        get() = prefs.getLong(KEY_EXPIRY_MS, 0L)
+        set(value) = prefs.edit().putLong(KEY_EXPIRY_MS, value).apply()
+
+    fun isLoggedIn(): Boolean = !accessToken.isNullOrBlank()
+
+    fun isTokenExpired(): Boolean = System.currentTimeMillis() >= tokenExpiryMs - 60_000L
+
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+
+    companion object {
+        private const val KEY_ACCESS_TOKEN  = "access_token"
+        private const val KEY_REFRESH_TOKEN = "refresh_token"
+        private const val KEY_USERNAME      = "username"
+        private const val KEY_EXPIRY_MS     = "expiry_ms"
+    }
+}

--- a/android/app/src/main/res/layout/activity_dashboard.xml
+++ b/android/app/src/main/res/layout/activity_dashboard.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/bg_dark">
+
+    <!-- Toolbar -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="12dp"
+        android:gravity="center_vertical"
+        android:background="@color/surface">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/app_name"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="@color/text_primary" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_load"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Refresh"
+            android:layout_marginEnd="8dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_logout"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Logout"
+            android:textColor="@color/text_secondary" />
+    </LinearLayout>
+
+    <!-- Filters -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="8dp"
+        android:gravity="center_vertical"
+        android:background="@color/surface">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Score ≤"
+            android:textColor="@color/text_secondary"
+            android:layout_marginEnd="4dp" />
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_max_score"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:inputType="numberSigned"
+            android:text="0"
+            android:textColor="@color/text_primary" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="  Age ≥"
+            android:textColor="@color/text_secondary"
+            android:layout_marginEnd="4dp" />
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_min_age"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:text="0"
+            android:textColor="@color/text_primary" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=" days"
+            android:textColor="@color/text_secondary" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_select_matching"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="Select Matching" />
+    </LinearLayout>
+
+    <!-- Select All / None -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="4dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_select_all"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Select All" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_select_none"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Select None" />
+
+        <View android:layout_width="0dp" android:layout_height="0dp" android:layout_weight="1" />
+
+        <TextView
+            android:id="@+id/tv_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/text_secondary"
+            android:textSize="12sp"
+            android:gravity="center_vertical" />
+    </LinearLayout>
+
+    <!-- Progress bar -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="4dp"
+        android:max="100"
+        android:visibility="gone" />
+
+    <!-- Tabs -->
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tab_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/surface">
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Comments" />
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Posts" />
+    </com.google.android.material.tabs.TabLayout>
+
+    <!-- Comment list -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_comments"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:visibility="visible" />
+
+    <!-- Post list -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_posts"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:visibility="gone" />
+
+    <!-- Delete button -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_delete"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:margin="12dp"
+        android:text="Delete Selected"
+        android:enabled="false"
+        android:backgroundTint="@color/reddit_orange" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/activity_login.xml
+++ b/android/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="32dp"
+    android:background="@color/bg_dark">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:textColor="@color/text_primary"
+        android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Bulk-delete your Reddit comments &amp; posts"
+        android:textSize="14sp"
+        android:textColor="@color/text_secondary"
+        android:gravity="center"
+        android:layout_marginBottom="48dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_login"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Login with Reddit"
+        android:textSize="16sp"
+        android:padding="14dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="Your credentials are never stored — only an OAuth token is kept on device."
+        android:textSize="12sp"
+        android:textColor="@color/text_secondary"
+        android:gravity="center" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/activity_oauth_callback.xml
+++ b/android/app/src/main/res/layout/activity_oauth_callback.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:background="@color/bg_dark">
+
+    <ProgressBar
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Completing sign-in…"
+        android:textColor="@color/text_secondary" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_reddit_row.xml
+++ b/android/app/src/main/res/layout/item_reddit_row.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="12dp"
+    android:gravity="center_vertical"
+    android:background="?attr/selectableItemBackground">
+
+    <CheckBox
+        android:id="@+id/check_box"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="12dp" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <!-- Row 1: type badge + subreddit + score + age -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="4dp">
+
+            <TextView
+                android:id="@+id/tv_type"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="10sp"
+                android:textColor="@color/reddit_orange"
+                android:textStyle="bold"
+                android:layout_marginEnd="6dp" />
+
+            <TextView
+                android:id="@+id/tv_subreddit"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="12sp"
+                android:textColor="@color/text_secondary" />
+
+            <TextView
+                android:id="@+id/tv_score"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textColor="@color/text_secondary"
+                android:layout_marginEnd="8dp" />
+
+            <TextView
+                android:id="@+id/tv_age"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textColor="@color/text_secondary" />
+        </LinearLayout>
+
+        <!-- Row 2: content preview -->
+        <TextView
+            android:id="@+id/tv_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textColor="@color/text_primary"
+            android:maxLines="2"
+            android:ellipsize="end" />
+    </LinearLayout>
+</LinearLayout>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="reddit_orange">#FF4500</color>
+    <color name="bg_dark">#121212</color>
+    <color name="surface">#1E1E1E</color>
+    <color name="text_primary">#FFFFFFFF</color>
+    <color name="text_secondary">#AAAAAA</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Reddit Comment Cleaner</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.RedditCommentCleaner" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">#FF4500</item>
+        <item name="colorPrimaryVariant">#CC3700</item>
+        <item name="colorOnPrimary">#FFFFFF</item>
+        <item name="colorSecondary">#FF6D3A</item>
+        <item name="android:windowBackground">@color/bg_dark</item>
+        <item name="android:statusBarColor">@color/surface</item>
+    </style>
+</resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+    ext.kotlin_version = '1.9.22'
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "RedditCommentCleaner"
+include ':app'


### PR DESCRIPTION
## Summary

Adds a native Android app under  using Kotlin, Retrofit, and Material Components.

### Authentication
- Reddit OAuth 2.0 **installed-app** flow with **PKCE S256** — no username/password ever stored
- Tokens kept in  (AES-256-GCM via Android Keystore)
- Access token auto-refreshed in an OkHttp interceptor before it expires

### Features
- **Browse** all comments and posts with full pagination
- **Filter** by score and age
- **Select** All / None / Matching items with one tap
- **Delete** selected: each item is edited to  then deleted (matching desktop behaviour)
- **Progress bar** during bulk deletion
- **Confirmation dialog** before any deletion
- **Logout** clears all stored tokens

### Stack
| Component | Library |
|-----------|---------|
| HTTP | Retrofit 2 + OkHttp 4 |
| JSON | Gson |
| UI | Material Components 1.11 |
| State | ViewModel + LiveData |
| Token storage | EncryptedSharedPreferences |
| OAuth browser | Chrome Custom Tabs |

## Setup
See  — the only required step is registering a Reddit **installed app** and pasting the  into .

## Test plan
- [ ] Open  in Android Studio, sync Gradle, build successfully
- [ ] Login flow opens Reddit OAuth page and completes without error
- [ ] Dashboard lists comments and posts
- [ ] Filters and selection controls work as expected
- [ ] Delete selected removes items from Reddit and from the list
- [ ] Logout returns to the login screen and clears tokens

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d