### PR TITLE
Log: add deleted_at timestamp and fix all dates to ISO 8601 UTC

### DIFF
--- a/PostCleaner.py
+++ b/PostCleaner.py
@@ -106,7 +106,9 @@ def delete_old_posts(reddit, username, days_old):
         if submission.created_utc < (time.time() - (days_old * 86400)):
             # save post title, date, karma, and subreddit deleted to a file with utf-8 encoding
             with open("deleted_posts.txt", "a", encoding="utf-8") as f:
-                f.write(f"{submission.title}, {datetime.utcfromtimestamp(submission.created_utc)}, {submission.score}, {submission.subreddit.display_name}\n")
+                created_at = datetime.utcfromtimestamp(submission.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+                f.write(f"{submission.title}, {created_at}, {deleted_at}, {submission.score}, {submission.subreddit.display_name}\n")
             try:
                 submission.edit(".")
                 submission.delete()

--- a/commentCleaner.py
+++ b/commentCleaner.py
@@ -102,10 +102,10 @@ def delete_old_comments(reddit, username, days_old, comments_deleted):
     """
     for comment in reddit.redditor(username).comments.new(limit=None):
         if time.time() - comment.created_utc > days_old * 24 * 60 * 60:
-            comment_date = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%d %H:%M:%S")
+            created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                # Write the date, karma score, and comment body to the file
-                f.write(f"{comment_date} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
             try:
                 comment.edit(".")
                 comment.delete()
@@ -128,10 +128,10 @@ def remove_comments_with_negative_karma(reddit, username, comments_deleted):
     """
     for comment in reddit.redditor(username).comments.new(limit=None):
         if comment.score <= 0:
-            comment_date = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%d %H:%M:%S")
+            created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                # Write the date, karma score, and comment body to the file
-                f.write(f"{comment_date} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
             try:
                 comment.edit(".")
                 comment.delete()
@@ -161,12 +161,10 @@ def remove_comments_with_one_karma_and_no_replies(reddit, username, comments_del
         comment.refresh()
         # Check if the comment meets the criteria
         if comment.score <= 1 and len(comment.replies) == 0 and datetime.utcfromtimestamp(comment.created_utc) < one_week_ago:
-            # Format the date of the comment
-            comment_date = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%d %H:%M:%S")
-
+            created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                # Write the date, karma score, and comment to the file
-                f.write(f"{comment_date} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
             try:
                 comment.edit(".")
                 comment.delete()

--- a/web/app.py
+++ b/web/app.py
@@ -126,9 +126,10 @@ def api_delete():
     for cid in comment_ids:
         try:
             comment = reddit.comment(cid)
-            date_str = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%d %H:%M:%S")
+            created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open(DELETED_COMMENTS_FILE, "a", encoding="utf-8") as f:
-                f.write(f"{date_str} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
             comment.edit(".")
             comment.delete()
             deleted_comments += 1
@@ -138,10 +139,13 @@ def api_delete():
     for pid in post_ids:
         try:
             submission = reddit.submission(pid)
+            created_at = datetime.utcfromtimestamp(submission.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open(DELETED_POSTS_FILE, "a", encoding="utf-8") as f:
                 f.write(
                     f"{submission.title}, "
-                    f"{datetime.utcfromtimestamp(submission.created_utc)}, "
+                    f"{created_at}, "
+                    f"{deleted_at}, "
                     f"{submission.score}, "
                     f"{submission.subreddit.display_name}\n"
                 )

--- a/weekly_cleanup.py
+++ b/weekly_cleanup.py
@@ -89,12 +89,13 @@ def main(dry_run: bool = False):
     print("Scanning comments…")
     for comment in reddit.redditor(username).comments.new(limit=None):
         if _should_delete(comment):
-            date_str = datetime.fromtimestamp(comment.created_utc, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            created_at = datetime.fromtimestamp(comment.created_utc, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            deleted_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             if dry_run:
                 print(f"  [DRY RUN] Would delete comment (score={comment.score}) in r/{comment.subreddit}: {comment.body[:80]!r}")
             else:
                 with open("deleted_comments.txt", "a", encoding="utf-8") as f:
-                    f.write(f"{date_str} | {comment.score} | {comment.body}\n")
+                    f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
                 try:
                     comment.edit(".")
                     comment.delete()
@@ -111,10 +112,13 @@ def main(dry_run: bool = False):
             if dry_run:
                 print(f"  [DRY RUN] Would delete post '{submission.title}' (score={submission.score}) in r/{submission.subreddit}")
             else:
+                created_at = datetime.fromtimestamp(submission.created_utc, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                deleted_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
                 with open("deleted_posts.txt", "a", encoding="utf-8") as f:
                     f.write(
                         f"{submission.title}, "
-                        f"{datetime.fromtimestamp(submission.created_utc, tz=timezone.utc)}, "
+                        f"{created_at}, "
+                        f"{deleted_at}, "
                         f"{submission.score}, "
                         f"{submission.subreddit.display_name}\n"
                     )


### PR DESCRIPTION
## What changed
Every log entry now records two distinct timestamps:
- `deleted_at` — **new**: when the script actually deleted the item (ISO 8601 UTC)
- `created_at` — renamed from the old unlabelled date column

Both use `YYYY-MM-DDTHH:MM:SSZ` format everywhere. Previously the post log printed a raw `datetime` object (included microseconds and `+00:00`) while the comment log used `%Y-%m-%d %H:%M:%S` without any timezone indicator.

## New column order
```
deleted_comments.txt:  deleted_at | created_at | score | body
deleted_posts.txt:     title, created_at, deleted_at, score, subreddit
```

## Files changed
`commentCleaner.py` (modes 1/2/3), `PostCleaner.py`, `weekly_cleanup.py`, `web/app.py`

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d