### PR TITLE
Log: add permalink URL to all log entries

### DIFF
--- a/PostCleaner.py
+++ b/PostCleaner.py
@@ -108,7 +108,7 @@ def delete_old_posts(reddit, username, days_old):
             with open("deleted_posts.txt", "a", encoding="utf-8") as f:
                 created_at = datetime.utcfromtimestamp(submission.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
                 deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-                f.write(f"{submission.title}, {created_at}, {deleted_at}, {submission.score}, {submission.subreddit.display_name}\n")
+                f.write(f"{submission.title}, {created_at}, {deleted_at}, {submission.score}, {submission.subreddit.display_name}, https://reddit.com{submission.permalink}\n")
             try:
                 submission.edit(".")
                 submission.delete()

--- a/commentCleaner.py
+++ b/commentCleaner.py
@@ -105,7 +105,7 @@ def delete_old_comments(reddit, username, days_old, comments_deleted):
             created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | https://reddit.com{comment.permalink} | {comment.body}\n")
             try:
                 comment.edit(".")
                 comment.delete()
@@ -131,7 +131,7 @@ def remove_comments_with_negative_karma(reddit, username, comments_deleted):
             created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | https://reddit.com{comment.permalink} | {comment.body}\n")
             try:
                 comment.edit(".")
                 comment.delete()
@@ -164,7 +164,7 @@ def remove_comments_with_one_karma_and_no_replies(reddit, username, comments_del
             created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | https://reddit.com{comment.permalink} | {comment.body}\n")
             try:
                 comment.edit(".")
                 comment.delete()

--- a/web/app.py
+++ b/web/app.py
@@ -129,7 +129,7 @@ def api_delete():
             created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open(DELETED_COMMENTS_FILE, "a", encoding="utf-8") as f:
-                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | https://reddit.com{comment.permalink} | {comment.body}\n")
             comment.edit(".")
             comment.delete()
             deleted_comments += 1
@@ -147,7 +147,8 @@ def api_delete():
                     f"{created_at}, "
                     f"{deleted_at}, "
                     f"{submission.score}, "
-                    f"{submission.subreddit.display_name}\n"
+                    f"{submission.subreddit.display_name}, "
+                    f"https://reddit.com{submission.permalink}\n"
                 )
             submission.edit(".")
             submission.delete()

--- a/weekly_cleanup.py
+++ b/weekly_cleanup.py
@@ -95,7 +95,7 @@ def main(dry_run: bool = False):
                 print(f"  [DRY RUN] Would delete comment (score={comment.score}) in r/{comment.subreddit}: {comment.body[:80]!r}")
             else:
                 with open("deleted_comments.txt", "a", encoding="utf-8") as f:
-                    f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                    f.write(f"{deleted_at} | {created_at} | {comment.score} | https://reddit.com{comment.permalink} | {comment.body}\n")
                 try:
                     comment.edit(".")
                     comment.delete()
@@ -120,7 +120,8 @@ def main(dry_run: bool = False):
                         f"{created_at}, "
                         f"{deleted_at}, "
                         f"{submission.score}, "
-                        f"{submission.subreddit.display_name}\n"
+                        f"{submission.subreddit.display_name}, "
+                        f"https://reddit.com{submission.permalink}\n"
                     )
                 try:
                     submission.edit(".")


### PR DESCRIPTION
## What changed
Each log entry now includes a direct URL to the deleted item. Reddit keeps deleted items accessible by direct URL for some time after deletion.

`comment.permalink` / `submission.permalink` returns a relative path; we prepend `https://reddit.com`.

## New column order
```
deleted_comments.txt:  date | score | permalink | body
deleted_posts.txt:     title, date, score, subreddit, permalink
```

## Files changed
`commentCleaner.py` (modes 1/2/3), `PostCleaner.py`, `weekly_cleanup.py`, `web/app.py`

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d