### PR TITLE
Log: add source field to identify which script deleted each item

### DIFF
--- a/PostCleaner.py
+++ b/PostCleaner.py
@@ -108,7 +108,7 @@ def delete_old_posts(reddit, username, days_old):
             with open("deleted_posts.txt", "a", encoding="utf-8") as f:
                 created_at = datetime.utcfromtimestamp(submission.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
                 deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-                f.write(f"{submission.title}, {created_at}, {deleted_at}, {submission.score}, {submission.subreddit.display_name}\n")
+                f.write(f"{submission.title}, {created_at}, {deleted_at}, {submission.score}, {submission.subreddit.display_name}, cli\n")
             try:
                 submission.edit(".")
                 submission.delete()

--- a/commentCleaner.py
+++ b/commentCleaner.py
@@ -105,7 +105,7 @@ def delete_old_comments(reddit, username, days_old, comments_deleted):
             created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | cli-mode-1 | {comment.body}\n")
             try:
                 comment.edit(".")
                 comment.delete()
@@ -131,7 +131,7 @@ def remove_comments_with_negative_karma(reddit, username, comments_deleted):
             created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | cli-mode-2 | {comment.body}\n")
             try:
                 comment.edit(".")
                 comment.delete()
@@ -164,7 +164,7 @@ def remove_comments_with_one_karma_and_no_replies(reddit, username, comments_del
             created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | cli-mode-3 | {comment.body}\n")
             try:
                 comment.edit(".")
                 comment.delete()

--- a/web/app.py
+++ b/web/app.py
@@ -129,7 +129,7 @@ def api_delete():
             created_at = datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ")
             deleted_at = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
             with open(DELETED_COMMENTS_FILE, "a", encoding="utf-8") as f:
-                f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                f.write(f"{deleted_at} | {created_at} | {comment.score} | web | {comment.body}\n")
             comment.edit(".")
             comment.delete()
             deleted_comments += 1
@@ -147,7 +147,8 @@ def api_delete():
                     f"{created_at}, "
                     f"{deleted_at}, "
                     f"{submission.score}, "
-                    f"{submission.subreddit.display_name}\n"
+                    f"{submission.subreddit.display_name}, "
+                    f"web\n"
                 )
             submission.edit(".")
             submission.delete()

--- a/weekly_cleanup.py
+++ b/weekly_cleanup.py
@@ -95,7 +95,7 @@ def main(dry_run: bool = False):
                 print(f"  [DRY RUN] Would delete comment (score={comment.score}) in r/{comment.subreddit}: {comment.body[:80]!r}")
             else:
                 with open("deleted_comments.txt", "a", encoding="utf-8") as f:
-                    f.write(f"{deleted_at} | {created_at} | {comment.score} | {comment.body}\n")
+                    f.write(f"{deleted_at} | {created_at} | {comment.score} | ci | {comment.body}\n")
                 try:
                     comment.edit(".")
                     comment.delete()
@@ -120,7 +120,8 @@ def main(dry_run: bool = False):
                         f"{created_at}, "
                         f"{deleted_at}, "
                         f"{submission.score}, "
-                        f"{submission.subreddit.display_name}\n"
+                        f"{submission.subreddit.display_name}, "
+                        f"ci\n"
                     )
                 try:
                     submission.edit(".")


### PR DESCRIPTION
## What changed
When logs accumulate across manual CLI runs, weekly CI runs, and web-app sessions it is impossible to tell what deleted what. Adds a `source` tag as the last column in both log files.

| Source value | Set by |
|---|---|
| `cli-mode-1` | `commentCleaner.py` — "Delete old comments" |
| `cli-mode-2` | `commentCleaner.py` — "Remove comments with negative karma" |
| `cli-mode-3` | `commentCleaner.py` — "Remove 1-karma no-reply comments" |
| `cli` | `PostCleaner.py` |
| `ci` | `weekly_cleanup.py` (GitHub Actions) |
| `web` | `web/app.py` |

## Files changed
`commentCleaner.py` (modes 1/2/3), `PostCleaner.py`, `weekly_cleanup.py`, `web/app.py`

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d