### PR TITLE
Fix ruff lint errors in test_drive_upload.py

### DIFF
--- a/tests/test_drive_upload.py
+++ b/tests/test_drive_upload.py
@@ -2,9 +2,7 @@
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 


### PR DESCRIPTION
Remove unused imports MagicMock and pytest that were causing the lint CI check to fail on main.

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d