### PR TITLE
Implement all improvements: utils, dry-run, CSRF, datetime, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,15 @@
 
 RedditCommentCleaner is a Python tool that allows Reddit users to bulk-delete their own comments and posts using the [PRAW](https://praw.readthedocs.io/) (Python Reddit API Wrapper) library. Before deletion, each item is edited to `"."` to prevent content-scraping tools from capturing the original text.
 
-It ships in three forms:
+It ships in four forms:
 - **CLI scripts** — interactive terminal tools (`commentCleaner.py`, `PostCleaner.py`)
 - **Web app** — browser-based dashboard for filtering and selectively deleting items (`web/`)
+- **Android app** — native Kotlin app with OAuth PKCE flow (`android/`)
 - **CI/CD** — automated weekly GitHub Actions run that deletes all items with score < 1
 
 **Current version:** 1.8
-**Language:** Python 3
-**Dependencies:** `praw` (CLI/CI), `praw` + `flask` (web app)
+**Language:** Python 3 (CLI/web/CI), Kotlin (Android)
+**Dependencies:** `praw` (CLI/CI), `praw` + `flask` + `flask-wtf` (web app)
 
 ---
 
@@ -22,12 +23,26 @@ RedditCommentCleaner/
 ├── commentCleaner.py              # CLI — comment deletion (3 modes)
 ├── PostCleaner.py                 # CLI — post/submission deletion
 ├── weekly_cleanup.py              # CI script — automated cleanup (score < 1)
+├── utils.py                       # Shared: _with_retry, credentials, reddit init
+├── drive_upload.py                # Optional Google Drive log upload helper
+├── requirements.txt               # CLI/CI deps: praw, google-api-python-client
 ├── web/
-│   ├── app.py                     # Flask web application
-│   ├── requirements.txt           # flask, praw
+│   ├── app.py                     # Flask web application (CSRF-protected)
+│   ├── requirements.txt           # flask, flask-wtf, praw, google-api-*
 │   └── templates/
 │       ├── index.html             # Login page
-│       └── dashboard.html        # Main dashboard UI
+│       └── dashboard.html         # Main dashboard UI
+├── android/                       # Native Android app (Kotlin + OAuth PKCE)
+│   ├── SETUP.md                   # Build and run instructions
+│   └── app/src/main/java/com/redditcommentcleaner/
+│       ├── auth/                  # LoginActivity, OAuthCallbackActivity
+│       ├── api/                   # RedditApiClient, RedditApiService
+│       ├── dashboard/             # DashboardActivity, DashboardViewModel
+│       └── util/                  # TokenStorage, PkceHelper
+├── scripts/
+│   └── backfill_drive_upload.py   # Upload all historical GitHub Actions artifacts to Drive
+├── tests/
+│   └── requirements.txt           # pytest, pytest-mock, flask, praw
 ├── .github/
 │   └── workflows/
 │       └── weekly-cleanup.yml     # GitHub Actions — runs weekly_cleanup.py
@@ -41,8 +56,8 @@ RedditCommentCleaner/
 
 | File | Created by | Contents |
 |---|---|---|
-| `deleted_comments.txt` | CLI scripts, web app, CI | `YYYY-MM-DD HH:MM:SS | score | body` |
-| `deleted_posts.txt` | CLI scripts, web app, CI | `title, UTC datetime, score, subreddit` |
+| `deleted_comments.txt` | CLI scripts, web app, CI | JSON lines — one object per deleted comment |
+| `deleted_posts.txt` | CLI scripts, web app, CI | JSON lines — one object per deleted post |
 | `Credentials.txt` | User | Reddit API credentials (CLI use only) |
 
 ---
@@ -51,15 +66,36 @@ RedditCommentCleaner/
 
 ### CLI scripts (`commentCleaner.py`, `PostCleaner.py`, `weekly_cleanup.py`)
 ```bash
-pip install praw
+pip install -r requirements.txt   # praw + google-api-python-client (Drive is optional)
 ```
 
 ### Web app (`web/`)
 ```bash
-pip install -r web/requirements.txt   # installs flask and praw
+pip install -r web/requirements.txt   # flask, flask-wtf, praw, google-api-*
+```
+
+### Tests
+```bash
+pip install -r tests/requirements.txt   # pytest, pytest-mock, flask, praw
 ```
 
 No `pyproject.toml`, Poetry, or Pipenv files exist.
+
+---
+
+## Shared Module — `utils.py`
+
+`utils.py` (repo root) is imported by both CLI scripts and `web/app.py`. It contains:
+
+| Symbol | Purpose |
+|--------|---------|
+| `_with_retry(fn, label)` | Calls `fn()`, retrying up to 3 times on `TooManyRequests` |
+| `get_reddit_credentials()` | Reads `Credentials.txt` or falls back to `input()` prompts |
+| `confirm_and_run()` | Asks the user yes/no before running |
+| `initialize_reddit(...)` | Creates and verifies a PRAW Reddit instance; catches `OAuthException` and `ResponseException` in addition to `APIException` |
+| `get_days_old(prompt)` | Prompts for an integer age threshold |
+
+`web/app.py` adds `BASE_DIR` to `sys.path` before importing `utils` (the same mechanism used for `drive_upload`).
 
 ---
 
@@ -102,17 +138,31 @@ Interactive CLI offering three deletion modes:
 | 2 | Delete all comments with score ≤ 0 |
 | 3 | Delete comments with score ≤ 1, no replies, older than 7 days |
 
+Supports `--dry-run` flag to preview deletions without making changes.
+
 **Flow:** load credentials → confirm → authenticate → loop (choose mode → run → report) → quit
 
 ### `PostCleaner.py`
 
 Single-pass CLI that deletes all posts older than N days.
 
+Supports `--dry-run` flag.
+
 **Flow:** load credentials → confirm → authenticate → prompt for age → `delete_old_posts`
 
 ### `weekly_cleanup.py`
 
-Non-interactive script designed for CI. Reads credentials from environment variables and deletes all comments **and** posts with `score < 1`. Logs each deleted item to `deleted_comments.txt` / `deleted_posts.txt`.
+Non-interactive script designed for CI. Reads credentials from environment variables and deletes all comments **and** posts with `score < 1` or `score == 1` AND older than 14 days. Logs each deleted item to `deleted_comments.txt` / `deleted_posts.txt`.
+
+Supports `--dry-run` flag (or `DRY_RUN=1` env var).
+
+### `scripts/backfill_drive_upload.py`
+
+One-off utility that downloads every historical `deletion-logs-*` artifact from the GitHub Actions workflow and uploads them to Google Drive with dated filenames. Requires the `gh` CLI authenticated and the `GOOGLE_SERVICE_ACCOUNT_KEY` / `GOOGLE_DRIVE_FOLDER_ID` env vars.
+
+```bash
+python scripts/backfill_drive_upload.py
+```
 
 ---
 
@@ -125,6 +175,8 @@ pip install -r web/requirements.txt
 python web/app.py
 # Open http://localhost:5000
 ```
+
+To enable debug mode: `FLASK_DEBUG=1 python web/app.py`
 
 ### Routes
 
@@ -149,7 +201,20 @@ python web/app.py
 
 - `web/app.py` uses `os.path.dirname(__file__)` to locate the repo root, so log files are always written to the repo root regardless of which directory you run Flask from.
 - Credentials are kept in a Flask session (server-side) and never sent to the browser.
+- CSRF protection is provided by **Flask-WTF** (`CSRFProtect`). The login form includes a hidden `csrf_token` field; the dashboard's `fetch('/api/delete')` call sends the token in the `X-CSRFToken` header (read from the `<meta name="csrf-token">` tag).
 - All PRAW calls are synchronous. For accounts with thousands of items, the initial `/api/items` request may take 30–60 seconds.
+
+---
+
+## Android App (`android/`)
+
+A native Kotlin app that mirrors the web app's functionality. See `android/SETUP.md` for full build instructions.
+
+Key characteristics:
+- Uses **OAuth PKCE** (installed-app flow) — no client secret needed
+- Tokens stored in **EncryptedSharedPreferences**
+- Edit → delete performed for each item before removal (same scraping prevention as the Python tools)
+- Requires registering an **installed app** at `https://www.reddit.com/prefs/apps` (redirect URI: `redditcommentcleaner://auth`)
 
 ---
 
@@ -163,11 +228,11 @@ python web/app.py
 
 **What it does:**
 1. Checks out the repo
-2. Installs `praw`
+2. Installs dependencies from `requirements.txt`
 3. Runs `python weekly_cleanup.py` with Reddit credentials from repository secrets
 4. Uploads `deleted_comments.txt` and `deleted_posts.txt` as workflow artifacts (retained 90 days)
 
-**Criteria:** deletes all comments and posts where `score < 1` (i.e., 0 or negative).
+**Criteria:** deletes all comments and posts where `score < 1` OR (`score == 1` AND older than 14 days).
 
 ---
 
@@ -192,6 +257,9 @@ These are pre-existing issues in the original codebase. Do not silently fix them
 # Interactive comment cleaner
 python commentCleaner.py
 
+# Dry-run preview (no deletions)
+python commentCleaner.py --dry-run
+
 # Interactive post cleaner
 python PostCleaner.py
 
@@ -199,9 +267,16 @@ python PostCleaner.py
 REDDIT_CLIENT_ID=... REDDIT_CLIENT_SECRET=... REDDIT_USERNAME=... REDDIT_PASSWORD=... \
   python weekly_cleanup.py
 
+# Dry-run the CI cleanup
+python weekly_cleanup.py --dry-run
+
 # Web app
 pip install -r web/requirements.txt
 python web/app.py   # then open http://localhost:5000
+
+# Run tests
+pip install -r tests/requirements.txt
+pytest tests/
 ```
 
 ---
@@ -210,10 +285,11 @@ python web/app.py   # then open http://localhost:5000
 
 - **Python version:** Python 3 (no pin; standard library uses `datetime`, `time`, `os`)
 - **Style:** No linter config. Google-style docstrings (`Args:`, `Returns:`, `Notes:`).
-- **No test suite.** Verify changes manually against a Reddit script-type developer app with a test account.
+- **Test suite:** `tests/` — run with `pytest`. Uses `pytest-mock` to mock PRAW objects.
 - **CI/CD:** GitHub Actions workflow added (`weekly-cleanup.yml`). No other pipelines.
-- **Error handling:** PRAW API errors caught as `praw.exceptions.APIException`. Auth failure calls `exit()` in CLI scripts; returns HTTP 401 in the web app.
+- **Error handling:** Auth failures catch `praw.exceptions.APIException`, `prawcore.exceptions.OAuthException`, and `prawcore.exceptions.ResponseException`. Rate limits retry via `_with_retry()`. Auth failure calls `exit()` in CLI scripts; returns HTTP 401 in the web app.
 - **Encoding:** All file writes use `encoding="utf-8"` explicitly.
+- **Datetimes:** All timestamps use `datetime.now(timezone.utc)` and `datetime.fromtimestamp(..., tz=timezone.utc)` — never the deprecated `utcnow()` / `utcfromtimestamp()`.
 - **`user_agent`:** Hardcoded as `'commentCleaner'` everywhere.
 
 ---
@@ -221,8 +297,9 @@ python web/app.py   # then open http://localhost:5000
 ## Reddit API Setup
 
 1. Go to `https://www.reddit.com/prefs/apps`
-2. Create a **script**-type app
-3. Note the `client_id` (under the app name) and `client_secret`
+2. Create a **script**-type app (for CLI/web/CI)
+3. Create an **installed app** (for Android — redirect URI: `redditcommentcleaner://auth`)
+4. Note the `client_id` (under the app name) and `client_secret`
 
 ---
 

--- a/PostCleaner.py
+++ b/PostCleaner.py
@@ -1,96 +1,22 @@
+import argparse
 import json
-import praw
 import time
-from datetime import datetime
+from datetime import datetime, timezone
+
+import praw
+import prawcore
 
 from drive_upload import maybe_upload_logs
+from utils import (
+    _with_retry,
+    confirm_and_run,
+    get_days_old,
+    get_reddit_credentials,
+    initialize_reddit,
+)
 
 
-def get_reddit_credentials(credentials_file="Credentials.txt"):
-    """
-    Prompt the user to input Reddit client credentials.
-
-    Args:
-        credentials_file (str): Path to the file containing Reddit client credentials.
-
-    Returns:
-        tuple: A tuple containing client_id, client_secret, username, and password.
-    """
-    try:
-        with open(credentials_file, 'r') as f:
-            client_id = f.readline().strip()
-            client_secret = f.readline().strip()
-            username = f.readline().strip()
-            password = f.readline().strip()
-            return client_id, client_secret, username, password
-    except FileNotFoundError:
-        print("Error: Could not find the credentials file.")
-
-    # If file reading fails or file is not found, prompt the user to input credentials manually
-    client_id = input("Enter your Reddit client ID: ")
-    client_secret = input("Enter your Reddit client secret: ")
-    username = input("Enter your Reddit username: ")
-    password = input("Enter your Reddit password: ")
-
-    return client_id, client_secret, username, password
-
-def confirm_and_run():
-    """
-    Ask the user for confirmation to run the script.
-
-    Returns:
-        bool: True if the user confirms, False otherwise.
-    """
-    confirmation = input("Do you want to run the script? (yes/no): ")
-    return confirmation.lower() == 'yes' or confirmation.lower() == 'y'
-
-def initialize_reddit(client_id, client_secret, username, password):
-    """
-    Initialize the Reddit instance with user credentials.
-
-    Args:
-        client_id (str): Reddit client ID.
-        client_secret (str): Reddit client secret.
-        username (str): Reddit username.
-        password (str): Reddit password.
-
-    Returns:
-        praw.Reddit: An authenticated Reddit instance.
-    """
-    try:
-        reddit = praw.Reddit(
-            client_id=client_id,
-            client_secret=client_secret,
-            username=username,
-            password=password,
-            user_agent='commentCleaner',
-            validate_on_submit=True
-        )
-        reddit.user.me()
-        print("Authenticated successfully.")
-        return reddit
-    except praw.exceptions.APIException:
-        print("Error: Could not authenticate with the provided credentials.")
-        exit()
-
-
-def get_days_old():
-    """
-    Prompt the user to input the age limit for comments.
-
-    Returns:
-        int: The number of days for the age limit.
-    """
-    while True:
-        days_old = input("Enter how old (in days) the post should be: ")
-        try:
-            days_old = int(days_old)
-            return days_old
-        except ValueError:
-            print("Error: Please enter a number.")
-
-
-def delete_old_posts(reddit, username, days_old):
+def delete_old_posts(reddit, username, days_old, *, dry_run=False):
     """
     Delete posts older than a specified number of days.
 
@@ -98,18 +24,37 @@ def delete_old_posts(reddit, username, days_old):
         reddit (praw.Reddit): An authenticated Reddit instance.
         username (str): Reddit username.
         days_old (int): The age limit for posts.
+        dry_run (bool): If True, log matches but do not delete.
 
     Returns:
-        int: The number of posts successfully deleted.
+        int: The number of posts successfully deleted (or matched in dry-run).
     """
+    threshold = time.time() - days_old * 86400
     posts_deleted = 0
-    for submission in reddit.redditor(username).submissions.new(limit=None):
-        if submission.created_utc < (time.time() - (days_old * 86400)):
-            # save post title, date, karma, and subreddit deleted to a file with utf-8 encoding
-            with open("deleted_posts.txt", "a", encoding="utf-8") as f:
-                f.write(json.dumps({
-                    "deleted_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "created_at": datetime.utcfromtimestamp(submission.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+
+    with open("deleted_posts.txt", "a", encoding="utf-8") as log_file:
+        for n, submission in enumerate(
+            reddit.redditor(username).submissions.new(limit=None), 1
+        ):
+            print(f"\r  Scanning… {n} post(s) fetched", end="", flush=True)
+
+            if submission.created_utc >= threshold:
+                continue  # too new
+
+            if dry_run:
+                print(
+                    f"\n  [DRY RUN] Would delete '{submission.title}'"
+                    f" (score={submission.score}) in r/{submission.subreddit}"
+                )
+                posts_deleted += 1
+                continue
+
+            log_file.write(
+                json.dumps({
+                    "deleted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "created_at": datetime.fromtimestamp(
+                        submission.created_utc, tz=timezone.utc
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "id": submission.name,
                     "subreddit": submission.subreddit.display_name,
                     "score": submission.score,
@@ -117,20 +62,31 @@ def delete_old_posts(reddit, username, days_old):
                     "permalink": f"https://reddit.com{submission.permalink}",
                     "num_comments": submission.num_comments,
                     "source": "cli",
-                }) + "\n")
+                }) + "\n"
+            )
             try:
-                submission.edit(".")
-                submission.delete()
+                _with_retry(lambda: submission.edit("."), "post edit")
+                _with_retry(submission.delete, "post delete")
                 posts_deleted += 1
-                print(f"Deleted post: {submission.title}")
-            except praw.exceptions.APIException as e:
-                print(f"Error removing post: {e}")
+                print(f"\n  Deleted post: {submission.title}")
+            except (praw.exceptions.APIException, prawcore.exceptions.TooManyRequests) as e:
+                print(f"\n  Error removing post: {e}")
 
-    print(f"Deleted {posts_deleted} posts.")
+    print()  # newline after the progress counter
+    label = "would delete" if dry_run else "Deleted"
+    print(f"{label} {posts_deleted} post(s).")
     return posts_deleted
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Interactive Reddit post cleaner")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview which posts would be deleted without making any changes",
+    )
+    args = parser.parse_args()
+
     client_id, client_secret, username, password = get_reddit_credentials()
 
     if not confirm_and_run():
@@ -138,9 +94,10 @@ def main():
         return
 
     reddit = initialize_reddit(client_id, client_secret, username, password)
-    days_old = get_days_old()
-    delete_old_posts(reddit, username, days_old)
-    maybe_upload_logs("deleted_posts.txt")
+    days_old = get_days_old("Enter how old (in days) the posts should be: ")
+    delete_old_posts(reddit, username, days_old, dry_run=args.dry_run)
+    if not args.dry_run:
+        maybe_upload_logs("deleted_posts.txt")
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 Bulk-delete your Reddit comments and posts. Each item is edited to `"."` before deletion to prevent content-scraping tools from capturing the original text.
 
-Available in three forms:
+Available in four forms:
 
 | Mode | Description |
 |------|-------------|
 | **CLI** | Interactive terminal scripts (`commentCleaner.py`, `PostCleaner.py`) |
 | **Web app** | Browser dashboard — filter, select, and delete items visually |
+| **Android** | Native Kotlin app with OAuth PKCE flow (`android/`) |
 | **CI/CD** | Automated weekly GitHub Actions run (score < 1, or score == 1 + older than 14 days) |
 
 ---
@@ -33,6 +34,13 @@ Available in three forms:
 ---
 
 ## CLI scripts
+
+Both scripts accept a `--dry-run` flag to preview which items would be deleted without making any changes:
+
+```bash
+python commentCleaner.py --dry-run
+python PostCleaner.py --dry-run
+```
 
 ### `commentCleaner.py` — delete comments
 
@@ -85,6 +93,19 @@ python web/app.py
 4. Click **Delete Selected** — deleted rows disappear from the table in-place
 
 Logs are written to `deleted_comments.txt` / `deleted_posts.txt` in the repo root.
+
+---
+
+## Android app
+
+A native Kotlin app that mirrors the web app. Uses Reddit's **OAuth 2.0 PKCE** flow (no client secret needed).
+
+See [`android/SETUP.md`](android/SETUP.md) for full build and run instructions.
+
+**Quick start:**
+1. Register an **installed app** at <https://www.reddit.com/prefs/apps> with redirect URI `redditcommentcleaner://auth`
+2. Add your client ID to `android/app/build.gradle`
+3. Build: `cd android && ./gradlew assembleDebug`
 
 ---
 
@@ -153,11 +174,25 @@ python weekly_cleanup.py
 
 ---
 
+## Backfilling historical logs to Drive
+
+If you enabled Google Drive uploads after the weekly cleanup had already run several times, you can upload all past GitHub Actions artifacts retroactively:
+
+```bash
+export GOOGLE_SERVICE_ACCOUNT_KEY=/path/to/key.json
+export GOOGLE_DRIVE_FOLDER_ID=your_folder_id
+python scripts/backfill_drive_upload.py
+```
+
+Requires the `gh` CLI to be installed and authenticated (`gh auth status`).
+
+---
+
 ## Output files
 
 | File | Created by | Format |
 |------|-----------|--------|
-| `deleted_comments.txt` | all scripts | `YYYY-MM-DD HH:MM:SS \| score \| body` |
-| `deleted_posts.txt` | all scripts | `title, datetime, score, subreddit` |
+| `deleted_comments.txt` | all scripts | JSON lines — one object per deleted comment |
+| `deleted_posts.txt` | all scripts | JSON lines — one object per deleted post |
 
 Both files are excluded from git (`.gitignore`) and uploaded as GitHub Actions artifacts (retained 90 days) in addition to the optional Drive upload.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,23 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.4   | &#x2717; |
-| 1.0   | :white_check_mark: |
+| Version | Supported |
+| ------- | --------- |
+| < 1.0   | &#x2717; |
+| 1.0     | &#x2717; |
+| 1.8     | &#x2713; |
 
 ## Reporting a Vulnerability
 
-Do a pull request or email me.
-As you can see the script has no home to call to, it communicates directly with reddit.
-Always review the code of the tools you are using!
+Open a **pull request** or **GitHub issue** describing the vulnerability.
+
+For sensitive disclosures that should not be public, you can also reach the maintainer via the email address listed on the GitHub profile.
+
+### Notes on attack surface
+
+- **CLI scripts** communicate only with the Reddit API via PRAW. They do not open any network ports, start any servers, or call any third-party services other than Reddit and (optionally) Google Drive.
+- **Web app** (`web/app.py`) exposes a local Flask server on port 5000. It should only be run on a trusted machine and network. It is not hardened for public internet exposure.
+- **Android app** uses Reddit's OAuth 2.0 PKCE flow with the official Reddit API. Tokens are stored in EncryptedSharedPreferences.
+- **Credentials** (Reddit password, API secret) are never written to disk by the web app or Android app; only the CLI scripts read them from `Credentials.txt`.
+
+Always review the code of the tools you are using before running them with your account credentials.

--- a/commentCleaner.py
+++ b/commentCleaner.py
@@ -1,94 +1,22 @@
+import argparse
 import json
-import praw
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+import praw
+import prawcore
 
 from drive_upload import maybe_upload_logs
-
-def get_reddit_credentials(credentials_file="Credentials.txt"):
-    """
-    Prompt the user to input Reddit client credentials.
-
-    Args:
-        credentials_file (str): Path to the file containing Reddit client credentials.
-
-    Returns:
-        tuple: A tuple containing client_id, client_secret, username, and password.
-    """
-    try:
-        with open(credentials_file, 'r') as f:
-            client_id = f.readline().strip()
-            client_secret = f.readline().strip()
-            username = f.readline().strip()
-            password = f.readline().strip()
-            return client_id, client_secret, username, password
-    except FileNotFoundError:
-        print("Error: Could not find the credentials file.")
-
-    # If file reading fails or file is not found, prompt the user to input credentials manually
-    client_id = input("Enter your Reddit client ID: ")
-    client_secret = input("Enter your Reddit client secret: ")
-    username = input("Enter your Reddit username: ")
-    password = input("Enter your Reddit password: ")
-
-    return client_id, client_secret, username, password
+from utils import (
+    _with_retry,
+    confirm_and_run,
+    get_days_old,
+    get_reddit_credentials,
+    initialize_reddit,
+)
 
 
-def get_days_old():
-    """
-    Prompt the user to input the age limit for comments.
-
-    Returns:
-        int: The number of days for the age limit.
-    """
-    while True:
-        days_old = input("Enter how old (in days) the comments should be: ")
-        try:
-            days_old = int(days_old)
-            return days_old
-        except ValueError:
-            print("Error: Please enter a number.")
-
-def confirm_and_run():
-    """
-    Ask the user for confirmation to run the script.
-
-    Returns:
-        bool: True if the user confirms, False otherwise.
-    """
-    confirmation = input("Do you want to run the script? (yes/no): ")
-    return confirmation.lower() == 'yes' or confirmation.lower() == 'y'
-
-def initialize_reddit(client_id, client_secret, username, password):
-    """
-    Initialize the Reddit instance with user credentials.
-
-    Args:
-        client_id (str): Reddit client ID.
-        client_secret (str): Reddit client secret.
-        username (str): Reddit username.
-        password (str): Reddit password.
-
-    Returns:
-        praw.Reddit: An authenticated Reddit instance.
-    """
-    try:
-        reddit = praw.Reddit(
-            client_id=client_id,
-            client_secret=client_secret,
-            username=username,
-            password=password,
-            user_agent='commentCleaner',
-            validate_on_submit=True
-        )
-        reddit.user.me()
-        print("Authenticated successfully.")
-        return reddit
-    except praw.exceptions.APIException:
-        print("Error: Could not authenticate with the provided credentials.")
-        exit()
-
-def delete_old_comments(reddit, username, days_old, comments_deleted):
+def delete_old_comments(reddit, username, days_old, comments_deleted, *, dry_run=False):
     """
     Delete comments older than a specified number of days.
 
@@ -97,32 +25,61 @@ def delete_old_comments(reddit, username, days_old, comments_deleted):
         username (str): Reddit username.
         days_old (int): Age limit for comments (in days).
         comments_deleted (list): A list to store deleted comments.
+        dry_run (bool): If True, log matches but do not delete.
 
     Notes:
-        This function will delete comments older than the specified age limit.
+        Since comments.new() is sorted newest-first, once a comment that meets
+        the age threshold is encountered every subsequent comment does too.
+        A ``past_cutoff`` flag skips redundant age checks after that transition.
     """
-    for comment in reddit.redditor(username).comments.new(limit=None):
-        if time.time() - comment.created_utc > days_old * 24 * 60 * 60:
-            with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                f.write(json.dumps({
-                    "deleted_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "created_at": datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    threshold_secs = days_old * 24 * 60 * 60
+    now = time.time()
+    past_cutoff = False
+
+    with open("deleted_comments.txt", "a", encoding="utf-8") as log_file:
+        for n, comment in enumerate(
+            reddit.redditor(username).comments.new(limit=None), 1
+        ):
+            print(f"\r  Scanning… {n} comment(s) fetched", end="", flush=True)
+
+            if not past_cutoff:
+                if now - comment.created_utc <= threshold_secs:
+                    continue  # too new; older comments follow later in the stream
+                past_cutoff = True  # all subsequent comments are also old enough
+
+            if dry_run:
+                print(
+                    f"\n  [DRY RUN] Would delete (score={comment.score})"
+                    f" in r/{comment.subreddit}: {comment.body[:60]!r}"
+                )
+                comments_deleted.append(comment)
+                continue
+
+            log_file.write(
+                json.dumps({
+                    "deleted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "created_at": datetime.fromtimestamp(
+                        comment.created_utc, tz=timezone.utc
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "id": comment.name,
                     "subreddit": str(comment.subreddit),
                     "score": comment.score,
                     "permalink": f"https://reddit.com{comment.permalink}",
                     "body": comment.body,
                     "source": "cli-mode-1",
-                }) + "\n")
+                }) + "\n"
+            )
             try:
-                comment.edit(".")
-                comment.delete()
+                _with_retry(lambda: comment.edit("."), "comment edit")
+                _with_retry(comment.delete, "comment delete")
                 comments_deleted.append(comment)
-            except praw.exceptions.APIException as e:
-                print(f"Error deleting comment: {e}")
+            except (praw.exceptions.APIException, prawcore.exceptions.TooManyRequests) as e:
+                print(f"\n  Error deleting comment: {e}")
+
+    print()  # newline after the progress counter
 
 
-def remove_comments_with_negative_karma(reddit, username, comments_deleted):
+def remove_comments_with_negative_karma(reddit, username, comments_deleted, *, dry_run=False):
     """
     Remove comments with negative karma.
 
@@ -130,32 +87,55 @@ def remove_comments_with_negative_karma(reddit, username, comments_deleted):
         reddit (praw.Reddit): Authenticated Reddit instance.
         username (str): Reddit username.
         comments_deleted (list): A list to store deleted comments.
+        dry_run (bool): If True, log matches but do not delete.
 
     Notes:
         This function will remove comments with a negative karma score.
     """
-    for comment in reddit.redditor(username).comments.new(limit=None):
-        if comment.score <= 0:
-            with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                f.write(json.dumps({
-                    "deleted_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "created_at": datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    with open("deleted_comments.txt", "a", encoding="utf-8") as log_file:
+        for n, comment in enumerate(
+            reddit.redditor(username).comments.new(limit=None), 1
+        ):
+            print(f"\r  Scanning… {n} comment(s) fetched", end="", flush=True)
+
+            if comment.score > 0:
+                continue
+
+            if dry_run:
+                print(
+                    f"\n  [DRY RUN] Would delete (score={comment.score})"
+                    f" in r/{comment.subreddit}: {comment.body[:60]!r}"
+                )
+                comments_deleted.append(comment)
+                continue
+
+            log_file.write(
+                json.dumps({
+                    "deleted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "created_at": datetime.fromtimestamp(
+                        comment.created_utc, tz=timezone.utc
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "id": comment.name,
                     "subreddit": str(comment.subreddit),
                     "score": comment.score,
                     "permalink": f"https://reddit.com{comment.permalink}",
                     "body": comment.body,
                     "source": "cli-mode-2",
-                }) + "\n")
+                }) + "\n"
+            )
             try:
-                comment.edit(".")
-                comment.delete()
+                _with_retry(lambda: comment.edit("."), "comment edit")
+                _with_retry(comment.delete, "comment delete")
                 comments_deleted.append(comment)
-            except praw.exceptions.APIException as e:
-                print(f"Error removing comment: {e}")
+            except (praw.exceptions.APIException, prawcore.exceptions.TooManyRequests) as e:
+                print(f"\n  Error removing comment: {e}")
+
+    print()
 
 
-def remove_comments_with_one_karma_and_no_replies(reddit, username, comments_deleted):
+def remove_comments_with_one_karma_and_no_replies(
+    reddit, username, comments_deleted, *, dry_run=False
+):
     """
     Remove comments with one karma, no replies, and are at least a week old.
 
@@ -163,38 +143,65 @@ def remove_comments_with_one_karma_and_no_replies(reddit, username, comments_del
         reddit (praw.Reddit): Authenticated Reddit instance.
         username (str): Reddit username.
         comments_deleted (list): A list to store deleted comments.
+        dry_run (bool): If True, log matches but do not delete.
 
     Notes:
-        This function will remove comments with a karma score of 1, no replies, and are at least a week old.
-        It will append the deleted comments with their creation date, karma score, and comment body to the 'deleted_comments.txt' file.
+        comment.refresh() is called so that comment.replies is populated;
+        PRAW does not fill it for listing results without an explicit refresh.
     """
-    # Define a timedelta of one week
-    one_week_ago = datetime.utcnow() - timedelta(days=7)
+    one_week_ago = datetime.now(timezone.utc) - timedelta(days=7)
 
-    for comment in reddit.redditor(username).comments.new(limit=None):
-        # comment.replies is not populated by default; refresh() fetches the full thread
-        comment.refresh()
-        # Check if the comment meets the criteria
-        if comment.score <= 1 and len(comment.replies) == 0 and datetime.utcfromtimestamp(comment.created_utc) < one_week_ago:
-            with open('deleted_comments.txt', 'a', encoding='utf-8') as f:
-                f.write(json.dumps({
-                    "deleted_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "created_at": datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    with open("deleted_comments.txt", "a", encoding="utf-8") as log_file:
+        for n, comment in enumerate(
+            reddit.redditor(username).comments.new(limit=None), 1
+        ):
+            print(f"\r  Scanning… {n} comment(s) fetched", end="", flush=True)
+
+            # comment.replies is not populated by default; refresh() fetches the full thread
+            comment.refresh()
+            created = datetime.fromtimestamp(comment.created_utc, tz=timezone.utc)
+            if not (comment.score <= 1 and len(comment.replies) == 0 and created < one_week_ago):
+                continue
+
+            if dry_run:
+                print(
+                    f"\n  [DRY RUN] Would delete (score={comment.score})"
+                    f" in r/{comment.subreddit}: {comment.body[:60]!r}"
+                )
+                comments_deleted.append(comment)
+                continue
+
+            log_file.write(
+                json.dumps({
+                    "deleted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "created_at": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "id": comment.name,
                     "subreddit": str(comment.subreddit),
                     "score": comment.score,
                     "permalink": f"https://reddit.com{comment.permalink}",
                     "body": comment.body,
                     "source": "cli-mode-3",
-                }) + "\n")
+                }) + "\n"
+            )
             try:
-                comment.edit(".")
-                comment.delete()
+                _with_retry(lambda: comment.edit("."), "comment edit")
+                _with_retry(comment.delete, "comment delete")
                 comments_deleted.append(comment)
-            except praw.exceptions.APIException as e:
-                print(f"Error removing comment: {e}")
+            except (praw.exceptions.APIException, prawcore.exceptions.TooManyRequests) as e:
+                print(f"\n  Error removing comment: {e}")
+
+    print()
+
 
 def main():
+    parser = argparse.ArgumentParser(description="Interactive Reddit comment cleaner")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview which comments would be deleted without making any changes",
+    )
+    args = parser.parse_args()
+
     client_id, client_secret, username, password = get_reddit_credentials()
 
     if not confirm_and_run():
@@ -206,31 +213,47 @@ def main():
     comments_deleted = []
 
     while True:
-        action = input("Choose an action (1 - Delete old comments, 2 - Remove comments with negative karma, 3 - Remove comments with 1 karma and no replies, 4 - Quit): ")
+        action = input(
+            "Choose an action"
+            " (1 - Delete old comments,"
+            " 2 - Remove comments with negative karma,"
+            " 3 - Remove comments with 1 karma and no replies,"
+            " 4 - Quit): "
+        )
 
-        if action == '1':
-            print("Working (Deleting old comments)...", end="\r")
-            days_old = get_days_old()
-            delete_old_comments(reddit, username, days_old, comments_deleted)
-        elif action == '2':
-            print("Working (Removing comments with negative karma)...", end="\r")
-            remove_comments_with_negative_karma(reddit, username, comments_deleted)
-        elif action == '3':
-            print("Working (Removing comments with one karma and no replies)...", end="\r")
-            remove_comments_with_one_karma_and_no_replies(reddit, username, comments_deleted)
-        elif action == '4':
+        if action == "1":
+            days_old = get_days_old("Enter how old (in days) the comments should be: ")
+            print(f"Working (Deleting comments older than {days_old} day(s))…")
+            delete_old_comments(
+                reddit, username, days_old, comments_deleted, dry_run=args.dry_run
+            )
+        elif action == "2":
+            print("Working (Removing comments with negative karma)…")
+            remove_comments_with_negative_karma(
+                reddit, username, comments_deleted, dry_run=args.dry_run
+            )
+        elif action == "3":
+            print("Working (Removing comments with 1 karma and no replies)…")
+            remove_comments_with_one_karma_and_no_replies(
+                reddit, username, comments_deleted, dry_run=args.dry_run
+            )
+        elif action == "4":
             break
         else:
             print("Invalid choice. Please select a valid option.")
+            continue
 
         time.sleep(1)
 
-        if len(comments_deleted) > 0:
-            print("The script ran successfully and deleted {} comments.".format(len(comments_deleted)))
-            maybe_upload_logs("deleted_comments.txt")
+        if comments_deleted:
+            label = "would delete" if args.dry_run else "deleted"
+            print(f"The script {label} {len(comments_deleted)} comment(s).")
+            if not args.dry_run:
+                maybe_upload_logs("deleted_comments.txt")
             comments_deleted = []
         else:
             print("There were no comments to delete.")
+
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-praw
-google-api-python-client
-google-auth
-google-auth-httplib2
+praw>=7.6,<8
+google-api-python-client>=2.0,<3
+google-auth>=2.0,<3
+google-auth-httplib2>=0.1,<1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pytest
-pytest-mock
-flask
-praw
+pytest>=7.0,<9
+pytest-mock>=3.0,<4
+flask>=2.3,<4
+praw>=7.6,<8

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,108 @@
+"""Shared utilities for RedditCommentCleaner CLI scripts."""
+
+import time
+
+import praw
+import prawcore
+
+_RETRY_WAIT = (5, 15, 45)
+
+
+def _with_retry(fn, label="operation"):
+    """Call fn(), retrying up to 3 times on rate-limit errors."""
+    for attempt, wait in enumerate(_RETRY_WAIT, start=1):
+        try:
+            return fn()
+        except prawcore.exceptions.TooManyRequests as exc:
+            retry_after = getattr(exc, "retry_after", None) or wait
+            print(f"  Rate limited on {label}. Waiting {retry_after}s (attempt {attempt}/3)…")
+            time.sleep(retry_after)
+        except praw.exceptions.APIException:
+            raise
+    return fn()
+
+
+def get_reddit_credentials(credentials_file="Credentials.txt"):
+    """Load credentials from file or fall back to interactive prompts.
+
+    Args:
+        credentials_file (str): Path to the file containing Reddit credentials.
+
+    Returns:
+        tuple: (client_id, client_secret, username, password)
+    """
+    try:
+        with open(credentials_file, "r") as f:
+            client_id = f.readline().strip()
+            client_secret = f.readline().strip()
+            username = f.readline().strip()
+            password = f.readline().strip()
+            return client_id, client_secret, username, password
+    except FileNotFoundError:
+        print("Error: Could not find the credentials file.")
+
+    client_id = input("Enter your Reddit client ID: ")
+    client_secret = input("Enter your Reddit client secret: ")
+    username = input("Enter your Reddit username: ")
+    password = input("Enter your Reddit password: ")
+    return client_id, client_secret, username, password
+
+
+def confirm_and_run():
+    """Ask the user for confirmation to run the script.
+
+    Returns:
+        bool: True if the user confirms, False otherwise.
+    """
+    confirmation = input("Do you want to run the script? (yes/no): ")
+    return confirmation.lower() in ("yes", "y")
+
+
+def initialize_reddit(client_id, client_secret, username, password):
+    """Initialize and return an authenticated Reddit instance.
+
+    Args:
+        client_id (str): Reddit client ID.
+        client_secret (str): Reddit client secret.
+        username (str): Reddit username.
+        password (str): Reddit password.
+
+    Returns:
+        praw.Reddit: An authenticated Reddit instance.
+    """
+    try:
+        reddit = praw.Reddit(
+            client_id=client_id,
+            client_secret=client_secret,
+            username=username,
+            password=password,
+            user_agent="commentCleaner",
+            validate_on_submit=True,
+        )
+        reddit.user.me()
+        print("Authenticated successfully.")
+        return reddit
+    except (
+        praw.exceptions.APIException,
+        prawcore.exceptions.OAuthException,
+        prawcore.exceptions.ResponseException,
+    ):
+        print("Error: Could not authenticate with the provided credentials.")
+        exit()
+
+
+def get_days_old(prompt="Enter how old (in days) the items should be: "):
+    """Prompt the user for an age limit in days.
+
+    Args:
+        prompt (str): Custom prompt text.
+
+    Returns:
+        int: The number of days.
+    """
+    while True:
+        days_old = input(prompt)
+        try:
+            return int(days_old)
+        except ValueError:
+            print("Error: Please enter a number.")

--- a/web/app.py
+++ b/web/app.py
@@ -1,21 +1,27 @@
 import json
 import os
 import sys
-from datetime import datetime
+import time
+from datetime import datetime, timezone
 
 import praw
+import prawcore
 from flask import Flask, jsonify, redirect, render_template, request, session, url_for
+from flask_wtf.csrf import CSRFProtect
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("FLASK_SECRET_KEY") or os.urandom(24)
+csrf = CSRFProtect(app)
 
 # Log files are kept at the repo root, not inside web/
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-# Allow importing drive_upload from the repo root
+# Allow importing drive_upload and utils from the repo root
 if BASE_DIR not in sys.path:
     sys.path.insert(0, BASE_DIR)
 from drive_upload import maybe_upload_logs  # noqa: E402
+from utils import _with_retry  # noqa: E402
+
 DELETED_COMMENTS_FILE = os.path.join(BASE_DIR, "deleted_comments.txt")
 DELETED_POSTS_FILE = os.path.join(BASE_DIR, "deleted_posts.txt")
 
@@ -55,7 +61,11 @@ def login():
         reddit.user.me()
         session.update(creds)
         return redirect(url_for("dashboard"))
-    except Exception as e:
+    except (
+        praw.exceptions.APIException,
+        prawcore.exceptions.OAuthException,
+        prawcore.exceptions.ResponseException,
+    ) as e:
         return render_template("index.html", error=f"Authentication failed: {e}")
 
 
@@ -73,6 +83,7 @@ def dashboard():
 
 
 @app.route("/api/items")
+@csrf.exempt
 def api_items():
     if "username" not in session:
         return jsonify(error="Not authenticated"), 401
@@ -89,7 +100,9 @@ def api_items():
             "score": c.score,
             "subreddit": str(c.subreddit),
             "created_utc": int(c.created_utc),
-            "created_date": datetime.utcfromtimestamp(c.created_utc).strftime("%Y-%m-%d"),
+            "created_date": datetime.fromtimestamp(
+                c.created_utc, tz=timezone.utc
+            ).strftime("%Y-%m-%d"),
             "permalink": "https://reddit.com" + c.permalink,
         })
 
@@ -102,7 +115,9 @@ def api_items():
             "score": s.score,
             "subreddit": str(s.subreddit),
             "created_utc": int(s.created_utc),
-            "created_date": datetime.utcfromtimestamp(s.created_utc).strftime("%Y-%m-%d"),
+            "created_date": datetime.fromtimestamp(
+                s.created_utc, tz=timezone.utc
+            ).strftime("%Y-%m-%d"),
             "num_comments": s.num_comments,
             "permalink": "https://reddit.com" + s.permalink,
         })
@@ -124,46 +139,60 @@ def api_delete():
     deleted_posts = 0
     errors = []
 
-    for cid in comment_ids:
-        try:
-            comment = reddit.comment(cid)
-            with open(DELETED_COMMENTS_FILE, "a", encoding="utf-8") as f:
-                f.write(json.dumps({
-                    "deleted_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "created_at": datetime.utcfromtimestamp(comment.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "id": comment.name,
-                    "subreddit": str(comment.subreddit),
-                    "score": comment.score,
-                    "permalink": f"https://reddit.com{comment.permalink}",
-                    "body": comment.body,
-                    "source": "web",
-                }) + "\n")
-            comment.edit(".")
-            comment.delete()
-            deleted_comments += 1
-        except Exception as e:
-            errors.append(f"Comment {cid}: {e}")
+    with open(DELETED_COMMENTS_FILE, "a", encoding="utf-8") as cf:
+        for cid in comment_ids:
+            try:
+                comment = reddit.comment(cid)
+                cf.write(
+                    json.dumps({
+                        "deleted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "created_at": datetime.fromtimestamp(
+                            comment.created_utc, tz=timezone.utc
+                        ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "id": comment.name,
+                        "subreddit": str(comment.subreddit),
+                        "score": comment.score,
+                        "permalink": f"https://reddit.com{comment.permalink}",
+                        "body": comment.body,
+                        "source": "web",
+                    }) + "\n"
+                )
+                _with_retry(lambda: comment.edit("."), "comment edit")
+                _with_retry(comment.delete, "comment delete")
+                deleted_comments += 1
+            except (
+                praw.exceptions.APIException,
+                prawcore.exceptions.PrawcoreException,
+            ) as e:
+                errors.append(f"Comment {cid}: {e}")
 
-    for pid in post_ids:
-        try:
-            submission = reddit.submission(pid)
-            with open(DELETED_POSTS_FILE, "a", encoding="utf-8") as f:
-                f.write(json.dumps({
-                    "deleted_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "created_at": datetime.utcfromtimestamp(submission.created_utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "id": submission.name,
-                    "subreddit": submission.subreddit.display_name,
-                    "score": submission.score,
-                    "title": submission.title,
-                    "permalink": f"https://reddit.com{submission.permalink}",
-                    "num_comments": submission.num_comments,
-                    "source": "web",
-                }) + "\n")
-            submission.edit(".")
-            submission.delete()
-            deleted_posts += 1
-        except Exception as e:
-            errors.append(f"Post {pid}: {e}")
+    with open(DELETED_POSTS_FILE, "a", encoding="utf-8") as pf:
+        for pid in post_ids:
+            try:
+                submission = reddit.submission(pid)
+                pf.write(
+                    json.dumps({
+                        "deleted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "created_at": datetime.fromtimestamp(
+                            submission.created_utc, tz=timezone.utc
+                        ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "id": submission.name,
+                        "subreddit": submission.subreddit.display_name,
+                        "score": submission.score,
+                        "title": submission.title,
+                        "permalink": f"https://reddit.com{submission.permalink}",
+                        "num_comments": submission.num_comments,
+                        "source": "web",
+                    }) + "\n"
+                )
+                _with_retry(lambda: submission.edit("."), "post edit")
+                _with_retry(submission.delete, "post delete")
+                deleted_posts += 1
+            except (
+                praw.exceptions.APIException,
+                prawcore.exceptions.PrawcoreException,
+            ) as e:
+                errors.append(f"Post {pid}: {e}")
 
     drive_links = maybe_upload_logs(DELETED_COMMENTS_FILE, DELETED_POSTS_FILE)
 
@@ -176,4 +205,4 @@ def api_delete():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    app.run(debug=os.environ.get("FLASK_DEBUG") == "1", port=5000)

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,6 @@
-flask
-praw
-google-api-python-client
-google-auth
-google-auth-httplib2
+flask>=2.3,<4
+flask-wtf>=1.1,<2
+praw>=7.6,<8
+google-api-python-client>=2.0,<3
+google-auth>=2.0,<3
+google-auth-httplib2>=0.1,<1

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
   <title>RedditCommentCleaner — Dashboard</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -550,9 +551,13 @@
 
     setLoader(true, `Deleting ${total} item(s)…`);
     try {
+      const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
       const res = await fetch('/api/delete', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken,
+        },
         body: JSON.stringify({ comment_ids: commentIds, post_ids: postIds }),
       });
       if (res.status === 401) { location.href = '/'; return; }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -95,6 +95,7 @@
     {% endif %}
 
     <form method="POST" action="/login">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="field">
         <label for="client_id">Client ID</label>
         <input type="text" id="client_id" name="client_id" required autocomplete="off" spellcheck="false">


### PR DESCRIPTION
Shared utilities (utils.py)
- Extract _with_retry, get_reddit_credentials, confirm_and_run, initialize_reddit, and get_days_old into utils.py so both CLI scripts and the web app import a single, maintained copy
- Fix initialize_reddit to catch prawcore.exceptions.OAuthException and ResponseException in addition to praw.exceptions.APIException so bad-credential errors are always handled cleanly

CLI scripts (commentCleaner.py, PostCleaner.py)
- Add --dry-run flag (argparse) to preview deletions without changes
- Add per-item progress counter (\r  Scanning… N items fetched)
- Open the log file once per function call instead of once per deletion
- Replace deprecated datetime.utcnow() / utcfromtimestamp() with timezone-aware datetime.now(timezone.utc) / fromtimestamp(..., tz=utc)
- Mode 1 (delete_old_comments): add past_cutoff flag to skip the age check for every item once the sorted stream crosses the threshold
- Wrap edit/delete calls with _with_retry for rate-limit resilience
- Add prawcore.exceptions.TooManyRequests to exception handlers

Web app (web/app.py, index.html, dashboard.html)
- Add CSRF protection via flask-wtf CSRFProtect; login form includes hidden csrf_token field; dashboard fetch sends X-CSRFToken header read from <meta name="csrf-token"> tag
- Fix debug=True hardcoded; now reads FLASK_DEBUG env var
- Replace bare except Exception with specific PRAW/prawcore exceptions in /login and /api/delete to avoid masking unexpected errors
- Import _with_retry from utils; wrap all edit/delete calls
- Open comment and post log files once per /api/delete request
- All datetime calls now timezone-aware (timezone.utc)

Requirements
- Pin version ranges in requirements.txt, web/requirements.txt, and tests/requirements.txt (e.g. praw>=7.6,<8, flask>=2.3,<4)
- Add flask-wtf>=1.1,<2 to web/requirements.txt

Documentation (CLAUDE.md, README.md, SECURITY.md)
- CLAUDE.md: add utils.py, android/, scripts/ to structure table; add sections for each; correct "No test suite" → "Test suite: tests/"; document --dry-run, FLASK_DEBUG, CSRF architecture, timezone convention
- README.md: add Android app section with quick-start; add backfill script section; add --dry-run note to CLI section; update output-file format description to reflect JSON-lines format
- SECURITY.md: update supported versions table to v1.8; expand reporting guidance; describe attack surface for each component

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d