### PR TITLE
Fix stale Android client ID instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,10 @@ See [`android/SETUP.md`](android/SETUP.md) for full build and run instructions.
 
 **Quick start:**
 1. Register an **installed app** at <https://www.reddit.com/prefs/apps> with redirect URI `redditcommentcleaner://auth`
-2. Add your client ID to `android/app/build.gradle`
+2. Add your client ID to `android/local.properties` (never committed): `reddit.client_id=YOUR_ID`
 3. Build: `cd android && ./gradlew assembleDebug`
+
+**Play Store release:** see [`android/SETUP.md`](android/SETUP.md) for signing config, ProGuard, and the privacy policy requirement.
 
 ---
 


### PR DESCRIPTION
Step 2 of the Android quick-start incorrectly told users to edit build.gradle directly. Now correctly points to local.properties and adds a one-liner with the exact key to set. Also adds a Play Store release pointer to android/SETUP.md.

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d