### PR TITLE
Add CI workflow gating PRs to main, testing, and dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, testing, dev]
+  push:
+    branches: [main, testing, dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies
+        run: pip install -r tests/requirements.txt
+
+      - name: Run tests
+        run: pytest tests/ -v


### PR DESCRIPTION
Runs pytest on every PR and push to any of the three long-lived branches. This is the status check to require in branch protection rules once the dev and testing branches are created on GitHub.

https://claude.ai/code/session_014HLhrFtCVRFnEyfRexiy3d